### PR TITLE
채팅 화면에서 메시지가 많아도 높이를 넘지 않으며, 스크롤로 이전 메시지를 계속 불러오기

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatMessageResponseDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatMessageResponseDTO.java
@@ -29,6 +29,8 @@ public class ChatMessageResponseDTO {
 	private String senderName;
 	private String senderEmail;
 	private String senderProfileImageUrl;
+	private com.goodee.coreconnect.user.enums.JobGrade senderJobGrade; // ⭐ 발신자 직급
+	private String senderDeptName; // ⭐ 발신자 부서명
 	private Integer unreadCount;
 	private String roomName;
 	private Boolean readYn;

--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatMessageResponseDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatMessageResponseDTO.java
@@ -27,6 +27,8 @@ public class ChatMessageResponseDTO {
 	private Integer roomId;
 	private Integer senderId;
 	private String senderName;
+	private String senderEmail;
+	private String senderProfileImageUrl;
 	private Integer unreadCount;
 	private String roomName;
 	private Boolean readYn;
@@ -52,6 +54,8 @@ public class ChatMessageResponseDTO {
                 .roomName(chat.getChatRoom() != null ? chat.getChatRoom().getRoomName() : null)
                 .senderId(chat.getSender() != null ? chat.getSender().getId() : null)
                 .senderName(chat.getSender() != null ? chat.getSender().getName() : null)
+                .senderEmail(chat.getSender() != null ? chat.getSender().getEmail() : null)
+                .senderProfileImageUrl(null) // Controller에서 S3Service로 변환하여 설정
                 .unreadCount(chat.getUnreadCount() != null ? chat.getUnreadCount() : 0)
                 .readYn(readYn) // ✨ 3. DTO에 포함!
                 .build();

--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatResponseDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatResponseDTO.java
@@ -30,6 +30,8 @@ public class ChatResponseDTO {
     private String senderName;
     private String senderEmail;
     private String senderProfileImageUrl;
+    private com.goodee.coreconnect.user.enums.JobGrade senderJobGrade; // ⭐ 발신자 직급
+    private String senderDeptName; // ⭐ 발신자 부서명
     private String notificationType;
     private Integer unreadCount;
 

--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatResponseDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatResponseDTO.java
@@ -28,6 +28,8 @@ public class ChatResponseDTO {
     private Integer roomId;
     private Integer senderId;
     private String senderName;
+    private String senderEmail;
+    private String senderProfileImageUrl;
     private String notificationType;
     private Integer unreadCount;
 
@@ -43,6 +45,8 @@ public class ChatResponseDTO {
             .roomId(chat.getChatRoom() != null ? chat.getChatRoom().getId() : null)
             .senderId(chat.getSender() != null ? chat.getSender().getId() : null)
             .senderName(chat.getSender() != null ? chat.getSender().getName() : null)
+            .senderEmail(chat.getSender() != null ? chat.getSender().getEmail() : null)
+            .senderProfileImageUrl(null) // Controller에서 S3Service로 변환하여 설정
             .unreadCount(chat.getUnreadCount() != null ? chat.getUnreadCount() : 0)
             .build();
     }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatUserResponseDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatUserResponseDTO.java
@@ -2,6 +2,7 @@ package com.goodee.coreconnect.chat.dto.response;
 
 import com.goodee.coreconnect.chat.entity.ChatRoomUser;
 import com.goodee.coreconnect.user.entity.User;
+import com.goodee.coreconnect.user.enums.JobGrade;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +20,10 @@ import lombok.ToString;
 public class ChatUserResponseDTO {
 	private Integer id;
 	private String name;
-	private String email;	
+	private String email;
+	private JobGrade jobGrade; // 직급
+	private String deptName; // 부서명
+	private String profileImageUrl; // 프로필 이미지 URL (S3 URL)
 	
 
     // ChatRoomUser → DTO
@@ -30,12 +34,16 @@ public class ChatUserResponseDTO {
     }
 
     // User → DTO
+    // ⚠️ 주의: profileImageUrl과 deptName은 Controller에서 명시적으로 설정해야 함 (Lazy Loading 문제)
     public static ChatUserResponseDTO fromEntity(User user) {
         if (user == null) return null;
         return ChatUserResponseDTO.builder()
                 .id(user.getId())
                 .name(user.getName())
                 .email(user.getEmail())
+                .jobGrade(user.getJobGrade()) // 직급
+                .deptName(null) // Controller에서 user.getDepartment().getDeptName()으로 명시적으로 설정 (Lazy Loading 방지)
+                .profileImageUrl(null) // Controller에서 S3Service로 변환하여 설정
                 .build();
     }
 }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatUserResponseDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatUserResponseDTO.java
@@ -1,6 +1,8 @@
 package com.goodee.coreconnect.chat.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.goodee.coreconnect.chat.entity.ChatRoomUser;
+import com.goodee.coreconnect.common.service.S3Service;
 import com.goodee.coreconnect.user.entity.User;
 import com.goodee.coreconnect.user.enums.JobGrade;
 
@@ -17,6 +19,7 @@ import lombok.ToString;
 @Setter
 @Builder
 @ToString
+@JsonInclude(JsonInclude.Include.ALWAYS) //  null 값도 JSON에 포함되도록 설정
 public class ChatUserResponseDTO {
 	private Integer id;
 	private String name;
@@ -26,15 +29,74 @@ public class ChatUserResponseDTO {
 	private String profileImageUrl; // 프로필 이미지 URL (S3 URL)
 	
 
-    // ChatRoomUser → DTO
+    // ChatRoomUser → DTO (S3Service 포함 버전 - 권장)
+    // S3Service를 파라미터로 받아서 profileImageKey를 S3 URL로 변환하여 설정
+    public static ChatUserResponseDTO fromEntity(ChatRoomUser cru, S3Service s3Service) {
+        if (cru == null || cru.getUser() == null) return null;
+        User user = cru.getUser();
+        return fromEntity(user, s3Service);
+    }
+
+    // User → DTO (S3Service 포함 버전 - 권장)
+    //  profileImageKey를 S3 전체 URL로 변환하여 profileImageUrl에 설정
+    public static ChatUserResponseDTO fromEntity(User user, S3Service s3Service) {
+        if (user == null) return null;
+        
+        // ⭐ 프로필 이미지 URL 변환 (user_profile_image_key → S3 URL)
+        String profileImageUrl = "";
+        String profileImageKey = user.getProfileImageKey();
+        
+        // ⚠️ 디버깅: profileImageKey 확인
+        System.out.println("[ChatUserResponseDTO.fromEntity] userId: " + user.getId() + 
+                          ", profileImageKey: " + profileImageKey);
+        
+        if (profileImageKey != null && !profileImageKey.isBlank()) {
+            try {
+                profileImageUrl = s3Service.getFileUrl(profileImageKey);
+                // ⚠️ 디버깅: 변환된 URL 확인
+                System.out.println("[ChatUserResponseDTO.fromEntity] profileImageUrl 생성 성공: " + 
+                                  (profileImageUrl != null ? profileImageUrl.substring(0, Math.min(50, profileImageUrl.length())) + "..." : "null"));
+            } catch (Exception e) {
+                System.err.println("[ChatUserResponseDTO.fromEntity] S3 URL 변환 실패: " + e.getMessage());
+                profileImageUrl = ""; // 예외 발생 시 빈 문자열
+            }
+        } else {
+            System.out.println("[ChatUserResponseDTO.fromEntity] profileImageKey가 null 또는 빈 문자열");
+        }
+        
+        // ⭐ 부서명 설정
+        String deptName = "";
+        if (user.getDepartment() != null) {
+            deptName = user.getDepartment().getDeptName();
+        }
+        
+        ChatUserResponseDTO dto = ChatUserResponseDTO.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .jobGrade(user.getJobGrade()) // 직급
+                .deptName(deptName) // 부서명
+                .profileImageUrl(profileImageUrl) // S3 URL로 변환된 프로필 이미지 URL
+                .build();
+        
+        // ⚠️ 디버깅: 최종 DTO 확인
+        System.out.println("[ChatUserResponseDTO.fromEntity] 최종 DTO - id: " + dto.getId() + 
+                          ", name: " + dto.getName() + 
+                          ", profileImageUrl: " + (dto.getProfileImageUrl() != null ? dto.getProfileImageUrl().substring(0, Math.min(50, dto.getProfileImageUrl().length())) + "..." : "null"));
+        
+        return dto;
+    }
+
+    // ChatRoomUser → DTO (S3Service 없이 - 하위 호환성용, Controller에서 추가 설정 필요)
+    @Deprecated // ⚠️ S3Service를 포함한 버전 사용 권장
     public static ChatUserResponseDTO fromEntity(ChatRoomUser cru) {
         if (cru == null || cru.getUser() == null) return null;
         User user = cru.getUser();
         return fromEntity(user);
     }
 
-    // User → DTO
-    // ⚠️ 주의: profileImageUrl과 deptName은 Controller에서 명시적으로 설정해야 함 (Lazy Loading 문제)
+    // User → DTO (S3Service 없이 - 하위 호환성용, Controller에서 추가 설정 필요)
+    @Deprecated // ⚠️ S3Service를 포함한 버전 사용 권장
     public static ChatUserResponseDTO fromEntity(User user) {
         if (user == null) return null;
         return ChatUserResponseDTO.builder()
@@ -42,8 +104,8 @@ public class ChatUserResponseDTO {
                 .name(user.getName())
                 .email(user.getEmail())
                 .jobGrade(user.getJobGrade()) // 직급
-                .deptName(null) // Controller에서 user.getDepartment().getDeptName()으로 명시적으로 설정 (Lazy Loading 방지)
-                .profileImageUrl(null) // Controller에서 S3Service로 변환하여 설정
+                .deptName("") // Controller에서 user.getDepartment().getDeptName()으로 명시적으로 설정 필요
+                .profileImageUrl("") // Controller에서 S3Service로 변환하여 설정 필요
                 .build();
     }
 }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatMessageReadStatusRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatMessageReadStatusRepository.java
@@ -8,19 +8,32 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import com.goodee.coreconnect.chat.entity.ChatMessageReadStatus;
+import com.goodee.coreconnect.chat.entity.ChatMessageReadStatusId; // ⭐ 복합키 클래스 import
 
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessageReadStatus, Integer>{
+// ⭐ 복합키 사용으로 ID 타입이 ChatMessageReadStatusId로 변경됨
+public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessageReadStatus, ChatMessageReadStatusId>{
 	// 1. 채팅 메시지별 미읽은 사용자 목록 조회
     @Query("SELECT r FROM ChatMessageReadStatus r WHERE r.chat.id = :chatId AND r.readYn = false")
     List<ChatMessageReadStatus> findUnreadByChatId(@Param("chatId") Integer chatId);
 
     // 2. 채팅방별로 각 메시지에 대해 미읽은 수 조회 가능
-	@Query("SELECT r.chat.id, COUNT(r) FROM ChatMessageReadStatus r WHERE r.chat.chatRoom.id = :roomId AND r.readYn = false GROUP BY r.chat.id")
+    // ⭐ 복합키 사용으로 COUNT(r) 대신 COUNT(1) 사용
+	@Query("SELECT r.chat.id, COUNT(1) FROM ChatMessageReadStatus r WHERE r.chat.chatRoom.id = :roomId AND r.readYn = false GROUP BY r.chat.id")
 	List<Object[]> countUnreadByRoomId(@Param("roomId") Integer roomId);
-    int countUnreadByChatId(Integer chatId);
+    
+    // ⭐ 특정 메시지(chatId)의 읽지 않은 사람 수 조회 (발신자 제외)
+    // 발신자는 메시지를 보낸 시점에 이미 readYn=true로 설정되므로, 
+    // unreadCount는 발신자를 제외한 참여자 중 읽지 않은 사람 수
+    // 참고: 발신자는 이미 readYn=true이므로 WHERE 조건에서 자동으로 제외됨
+    // 하지만 명시적으로 발신자를 제외하여 일관성 유지
+    // ⭐ 복합키 사용으로 COUNT(r) 대신 COUNT(1) 사용
+    @Query("SELECT COUNT(1) FROM ChatMessageReadStatus r " +
+           "WHERE r.chat.id = :chatId AND r.readYn = false " +
+           "AND r.user.id != (SELECT c.sender.id FROM Chat c WHERE c.id = :chatId)")
+    int countUnreadByChatId(@Param("chatId") Integer chatId);
 
     // 3. 사용자별 미읽은 메시지 조회 
     @Query("SELECT r FROM ChatMessageReadStatus r WHERE r.user.id = :userId AND r.readYn = false")
@@ -28,7 +41,8 @@ public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessa
     
     
     // 4. 채팅방별 내가 안읽은 메시지 개수
-    @Query("SELECT r.chat.chatRoom.id, COUNT(r) FROM ChatMessageReadStatus r WHERE r.user.id = :userId AND r.readYn = false GROUP BY r.chat.chatRoom.id")
+    // ⭐ 복합키 사용으로 COUNT(r) 대신 COUNT(1) 사용
+    @Query("SELECT r.chat.chatRoom.id, COUNT(1) FROM ChatMessageReadStatus r WHERE r.user.id = :userId AND r.readYn = false GROUP BY r.chat.chatRoom.id")
     List<Object[]> countUnreadByRoomIdForUser(@Param("userId") Integer userId);
     
     // 5. 해당 채팅방의 내가 안읽은 메시지 목록
@@ -49,7 +63,8 @@ public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessa
     List<ChatMessageReadStatus> fetchUnreadWithSender(@Param("userId") Integer userId);
     
  // 내(userId)가 특정 채팅방(roomId)에서 읽지 않은 개수 집계
-    @Query("SELECT COUNT(r) FROM ChatMessageReadStatus r WHERE r.user.id = :userId AND r.chat.chatRoom.id = :roomId AND r.readYn = false")
+    // ⭐ 복합키 사용으로 COUNT(r) 대신 COUNT(1) 사용
+    @Query("SELECT COUNT(1) FROM ChatMessageReadStatus r WHERE r.user.id = :userId AND r.chat.chatRoom.id = :roomId AND r.readYn = false")
     int countByUserIdAndChatRoomIdAndReadYnFalse(@Param("userId") Integer userId, @Param("roomId") Integer roomId);
 
     // 내(userId) 지정 방(roomId)의 안읽은 메시지 중, 가장 최근 1건
@@ -69,7 +84,8 @@ public interface ChatMessageReadStatusRepository extends JpaRepository<ChatMessa
     
     // 내가 참여중인 모든 채팅방에서 방별 unread 메시지 개수 집계
     // 결과: roomId, unreadCount로 반환 + 방 ID 단위로 내가 안읽은 메시지 개수 그룹핑
-    @Query("SELECT c.chat.chatRoom.id AS roomId, COUNT(c) AS unreadCount FROM ChatMessageReadStatus c WHERE c.user.id = :userId AND c.readYn = false GROUP BY c.chat.chatRoom.id")
+    // ⭐ 복합키 사용으로 COUNT(c) 대신 COUNT(1) 사용
+    @Query("SELECT c.chat.chatRoom.id AS roomId, COUNT(1) AS unreadCount FROM ChatMessageReadStatus c WHERE c.user.id = :userId AND c.readYn = false GROUP BY c.chat.chatRoom.id")
     List<Object[]> countUnreadMessagesByUserId(@Param("userId") Integer userId);
     
     // 올바른 JPA 네이밍 방식 적용!

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
@@ -17,8 +17,8 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     // 1. 채팅방의 모든 메시지
     List<Chat> findByChatRoomId(Integer id);
 
-    // 2. 여러 채팅방의 모든 메시지
-    @Query("SELECT c FROM Chat c WHERE c.chatRoom.id IN :roomIds")
+    // 2. 여러 채팅방의 모든 메시지 (sender도 함께 로드)
+    @Query("SELECT c FROM Chat c LEFT JOIN FETCH c.sender WHERE c.chatRoom.id IN :roomIds")
     List<Chat> findByChatRoomIds(@Param("roomIds") List<Integer> roomIds);
 
     // 3. 채팅방의 모든 메시지(오름차순)
@@ -53,13 +53,16 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     // 8. 채팅방에서 메시지를 불러올때 파일이 있는 경우 파일들도 함께 조회
     @Query("SELECT DISTINCT c FROM Chat c " + 
     	   "LEFT JOIN FETCH c.messageFiles " + 
+    	   "LEFT JOIN FETCH c.sender " +
     		"WHERE c.chatRoom.id = :roomId " + 
     	   "ORDER BY c.sendAt ASC")
     List<Chat> findAllChatsWithFilesByRoomId(@Param("roomId") Integer roomId);
     
     // 8-1. 채팅방에서 메시지를 페이징으로 불러올때 파일이 있는 경우 파일들도 함께 조회 (최신 메시지부터)
+    // sender도 함께 JOIN FETCH하여 user_profile_image_key를 가져올 수 있도록 함
     @Query("SELECT DISTINCT c FROM Chat c " + 
     	   "LEFT JOIN FETCH c.messageFiles " + 
+    	   "LEFT JOIN FETCH c.sender " +
     		"WHERE c.chatRoom.id = :roomId " + 
     	   "ORDER BY c.sendAt DESC")
     Page<Chat> findChatsWithFilesByRoomIdPaged(@Param("roomId") Integer roomId, Pageable pageable);

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
@@ -42,7 +42,8 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     List<Chat> findLatestMessageByChatRoomIds(@Param("roomIds") List<Integer> roomIds);
 
     // 6. 채팅방 내에서 특정 메시지의 미읽은 인원 조회 (ChatMessageReadStatus 활용)
-    @Query("SELECT r.chat.id, COUNT(r) FROM ChatMessageReadStatus r WHERE r.chat.chatRoom.id = :roomId AND r.readYn = false GROUP BY r.chat.id")
+    // ⭐ 복합키 사용으로 COUNT(r) 대신 COUNT(1) 사용
+    @Query("SELECT r.chat.id, COUNT(1) FROM ChatMessageReadStatus r WHERE r.chat.chatRoom.id = :roomId AND r.readYn = false GROUP BY r.chat.id")
     List<Object[]> countUnreadByRoomId(@Param("roomId") Integer roomId);
     
     // 7. 각 채팅방의 가장 마지막(최신) 메시지
@@ -85,6 +86,7 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     
     
     // 10. 채팅방 목록 불러올 때 unreadcount 필드 채워서 DTO로 변환
-    @Query("SELECT c.chat.chatRoom.id AS roomId, COUNT(c) AS unreadCount FROM ChatMessageReadStatus c WHERE c.user.id = :userId AND c.readYn = false GROUP BY c.chat.chatRoom.id")
+    // ⭐ 복합키 사용으로 COUNT(c) 대신 COUNT(1) 사용
+    @Query("SELECT c.chat.chatRoom.id AS roomId, COUNT(1) AS unreadCount FROM ChatMessageReadStatus c WHERE c.user.id = :userId AND c.readYn = false GROUP BY c.chat.chatRoom.id")
     List<Object[]> countUnreadMessagesByUserId(@Param("userId") Integer userId);
 }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
@@ -2,6 +2,8 @@ package com.goodee.coreconnect.chat.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -54,6 +56,13 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     		"WHERE c.chatRoom.id = :roomId " + 
     	   "ORDER BY c.sendAt ASC")
     List<Chat> findAllChatsWithFilesByRoomId(@Param("roomId") Integer roomId);
+    
+    // 8-1. 채팅방에서 메시지를 페이징으로 불러올때 파일이 있는 경우 파일들도 함께 조회 (최신 메시지부터)
+    @Query("SELECT DISTINCT c FROM Chat c " + 
+    	   "LEFT JOIN FETCH c.messageFiles " + 
+    		"WHERE c.chatRoom.id = :roomId " + 
+    	   "ORDER BY c.sendAt DESC")
+    Page<Chat> findChatsWithFilesByRoomIdPaged(@Param("roomId") Integer roomId, Pageable pageable);
     
 
     /** 

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRoomUserRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRoomUserRepository.java
@@ -14,7 +14,7 @@ import com.goodee.coreconnect.chat.entity.ChatRoomUser;
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Integer> {
 	List<ChatRoomUser> findByChatRoomId(Integer chatRoomId);
 	
-	@Query("SELECT cru FROM ChatRoomUser cru JOIN FETCH cru.user WHERE cru.chatRoom.id = :roomId")
+	@Query("SELECT cru FROM ChatRoomUser cru JOIN FETCH cru.user LEFT JOIN FETCH cru.user.department WHERE cru.chatRoom.id = :roomId")
 	List<ChatRoomUser> findByChatRoomIdWithUser(@Param("roomId") Integer roomId);
 	
 	// 내가 참여한 모든 채팅방

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
@@ -63,7 +63,8 @@ public interface ChatRoomService {
     
     List<ChatRoomSummaryResponseDTO> getChatRoomSummariesByUserId(Integer userId);
 
-    void markMessagesAsRead(Integer roomId, Integer userId);
+    // ⭐ 읽음 처리된 메시지 ID 리스트 반환 (WebSocket 알림용)
+    List<Integer> markMessagesAsRead(Integer roomId, Integer userId);
 
     /** 채팅방에서 현재 접속 중인 인원 id 리스트 반환 */
     List<Integer> getConnectedUserIdsInRoom(Integer roomId);

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
@@ -80,6 +80,9 @@ public interface ChatRoomService {
     // 채팅 메시지에 파일이 있는 경우 파일을 조회
     List<Chat> getChatsWithFilesByRoomId(Integer roomId);
     
+    // 채팅 메시지를 페이징으로 조회 (파일 포함)
+    org.springframework.data.domain.Page<Chat> getChatsWithFilesByRoomIdPaged(Integer roomId, org.springframework.data.domain.Pageable pageable);
+    
     boolean existsRoom(Integer roomId);
     
     // user 참여 chatRoom 목록 가져오기

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
@@ -283,7 +283,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
 	@Override
 	public List<ChatRoomUser> getChatRoomUsers(Integer roomId) {
-		return chatRoomUserRepository.findByChatRoomId(roomId);
+		// ⭐ User와 Department를 함께 조회하여 Lazy Loading 문제 해결
+		return chatRoomUserRepository.findByChatRoomIdWithUser(roomId);
 	}
 
 	@Override

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
@@ -587,6 +587,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		
 		return chats;
 	}
+	
+	@Override
+	public org.springframework.data.domain.Page<Chat> getChatsWithFilesByRoomIdPaged(Integer roomId, org.springframework.data.domain.Pageable pageable) {
+		return chatRepository.findChatsWithFilesByRoomIdPaged(roomId, pageable);
+	}
 
 	@Override
 	public boolean existsRoom(Integer roomId) {

--- a/backend/src/main/java/com/goodee/coreconnect/common/service/S3Service.java
+++ b/backend/src/main/java/com/goodee/coreconnect/common/service/S3Service.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
@@ -18,6 +19,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  * S3 업로드용 Service 파일
  */
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
@@ -43,13 +45,30 @@ public class S3Service {
 
     /** 공용: 업로드된 S3 객체의 key를 받아, 해당 파일에 접근할 수 있는 전체 URL을 생성하여 반환 */
     public String getFileUrl(String key) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("S3 key는 null이거나 빈 문자열일 수 없습니다.");
+        }
+        
         GetUrlRequest request = GetUrlRequest.builder()
                 .bucket(bucket)
                 .key(key)
                 .build();
 
         URL url = s3Client.utilities().getUrl(request);
-        return url.toString();
+        String urlString = url.toString();
+        
+        // ⭐ 디버깅: S3 URL 생성 로그 (프로필 이미지 문제 추적용)
+        // 생성된 URL이 완전한 URL인지 확인 (https://로 시작해야 함)
+        log.info("[S3Service] getFileUrl 호출 - key: {}, bucket: {}, 생성된URL: {}", key, bucket, urlString);
+        
+        // URL 형식 검증: https:// 또는 http://로 시작해야 함
+        if (!urlString.startsWith("http://") && !urlString.startsWith("https://")) {
+            log.error("[S3Service] ⚠️ 경고: 생성된 URL이 완전한 URL 형식이 아닙니다! key: {}, url: {}", key, urlString);
+        } else {
+            log.debug("[S3Service] ✅ 완전한 URL 생성 성공: {}", urlString);
+        }
+        
+        return urlString;
     }
     
     /**

--- a/backend/src/main/java/com/goodee/coreconnect/common/service/S3Service.java
+++ b/backend/src/main/java/com/goodee/coreconnect/common/service/S3Service.java
@@ -57,7 +57,7 @@ public class S3Service {
         URL url = s3Client.utilities().getUrl(request);
         String urlString = url.toString();
         
-        // ⭐ 디버깅: S3 URL 생성 로그 (프로필 이미지 문제 추적용)
+        // 디버깅: S3 URL 생성 로그 (프로필 이미지 문제 추적용)
         // 생성된 URL이 완전한 URL인지 확인 (https://로 시작해야 함)
         log.info("[S3Service] getFileUrl 호출 - key: {}, bucket: {}, 생성된URL: {}", key, bucket, urlString);
         

--- a/backend/src/main/java/com/goodee/coreconnect/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/goodee/coreconnect/config/WebSocketConfig.java
@@ -1,10 +1,16 @@
 package com.goodee.coreconnect.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.web.socket.config.annotation.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
@@ -14,21 +20,46 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        log.info("🔥 [WebSocketConfig] STOMP 엔드포인트 등록 시작");
         // 엔드포인트 경로, allow origins 등 설정
         registry.addEndpoint("/ws/chat")
                 .setAllowedOrigins("http://localhost:5173", "http://13.125.225.211:5173", "http://13.125.225.211") // 또는 필요한 경우 allowedOrigins 파라미터 넣기
                 .addInterceptors(webSocketAuthInterceptor) // WebSocket 인증 인터셉터 추가
                 .withSockJS(); // 필요하다면 SockJS 지원도 추가
+        log.info("🔥 [WebSocketConfig] /ws/chat 엔드포인트 등록 완료");
         // registry.addEndpoint("/ws/notification") ... 도 가능
         registry.addEndpoint("/ws/notification")
         .setAllowedOrigins("http://localhost:5173")
         .withSockJS();
+        log.info("🔥 [WebSocketConfig] STOMP 엔드포인트 등록 완료");
     }
+    
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
+        log.info("🔥 [WebSocketConfig] 메시지 브로커 설정 시작");
         // /topic/* 으로 publish 될 메시지는 내부 메시지 브로커에서 관리 (방송)
         registry.enableSimpleBroker("/topic", "/queue");
+        log.info("🔥 [WebSocketConfig] SimpleBroker 활성화: /topic, /queue");
         // 클라이언트가 /app으로 시작하는 주소로 send한 메시지는 @MessageMapping 대상으로 전달
         registry.setApplicationDestinationPrefixes("/app");
+        log.info("🔥 [WebSocketConfig] ApplicationDestinationPrefixes 설정: /app");
+        log.info("🔥 [WebSocketConfig] 메시지 브로커 설정 완료");
+    }
+    
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        log.info("🔥 [WebSocketConfig] 클라이언트 인바운드 채널 설정 시작");
+        // STOMP 메시지가 서버로 들어올 때 인터셉터 추가 가능
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                Object destination = message.getHeaders().get("simpDestination");
+                log.info("🔥 [WebSocketConfig] ========== STOMP 메시지 수신 ========== - destination: {}, headers: {}", 
+                        destination, 
+                        message.getHeaders());
+                return message;
+            }
+        });
+        log.info("🔥 [WebSocketConfig] 클라이언트 인바운드 채널 설정 완료");
     }
 }

--- a/backend/src/main/java/com/goodee/coreconnect/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/user/repository/UserRepository.java
@@ -18,6 +18,19 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    
+    /**
+     * ⭐ Department를 함께 로드하여 LazyInitializationException 방지
+     * @param email 사용자 이메일
+     * @return Department가 함께 로드된 User Optional
+     */
+    @Query("""
+        SELECT u FROM User u
+        LEFT JOIN FETCH u.department
+        WHERE u.email = :email
+        """)
+    Optional<User> findByEmailWithDepartment(@Param("email") String email);
+    
     Long countByStatus(Status status);
     
     @Query("""
@@ -27,6 +40,18 @@ public interface UserRepository extends JpaRepository<User, Integer> {
         ORDER BY d.deptOrderNo, u.name
         """)
     List<User> findAllForOrganization();
+    
+    /**
+     * ⭐ Department를 함께 로드하여 LazyInitializationException 방지
+     * @param id 사용자 ID
+     * @return Department가 함께 로드된 User Optional
+     */
+    @Query("""
+        SELECT u FROM User u
+        LEFT JOIN FETCH u.department
+        WHERE u.id = :id
+        """)
+    Optional<User> findByIdWithDepartment(@Param("id") Integer id);
     
     /**
      * 특정 연도로 시작하는 사번 중 최대값 조회 (동시성 처리를 위한 락 사용)

--- a/frontend/src/features/chat/api/ChatRoomApi.js
+++ b/frontend/src/features/chat/api/ChatRoomApi.js
@@ -24,13 +24,11 @@ export async function fetchUnreadmessages() {
 }
 
 // 채팅바에서 모든 메시지를 읽음처리 (PATCH)
-export const markRoomMessagesAsRead = async (roomId, accessToken) => {
+// ⭐ 쿠키 기반 인증 사용 (http.js에서 withCredentials: true 설정)
+// Authorization 헤더는 불필요하며, 쿠키로 자동 인증됨
+export const markRoomMessagesAsRead = async (roomId) => {
   // PATCH /api/v1/chat/rooms/{roomId}/messages/read
-  const res = await http.patch(
-    `/chat/rooms/${roomId}/messages/read`,
-    null,
-    {headers: {Authorization: `Bearer ${accessToken}`}}
-  );
+  const res = await http.patch(`/chat/rooms/${roomId}/messages/read`);
   return res.data;
 }
 

--- a/frontend/src/features/chat/api/ChatRoomApi.js
+++ b/frontend/src/features/chat/api/ChatRoomApi.js
@@ -8,9 +8,11 @@ export async function fetchChatRoomsLatest() {
   return res.data;
 }
 
-// 채팅방별 전체 메시지 (roomId 기준)
-export async function fetchChatRoomMessages(roomId) {
-  const res = await http.get(`/chat/${roomId}/messages`);
+// 채팅방별 전체 메시지 (roomId 기준) - 페이징 지원
+export async function fetchChatRoomMessages(roomId, page = 0, size = 20) {
+  const res = await http.get(`/chat/${roomId}/messages`, {
+    params: { page, size }
+  });
   return res.data;
 }
 

--- a/frontend/src/features/chat/api/ChatRoomApi.js
+++ b/frontend/src/features/chat/api/ChatRoomApi.js
@@ -45,3 +45,9 @@ export async function createChatRoom(data) {
   // ResponseDTO로 감싸져 있으면 res.data.data, 아니면 res.data
   return res.data; // { id, roomName, roomType, ... } 또는 { data: { id, ... } }
 }
+
+// 채팅방 참여자 목록 조회 API
+export async function fetchChatRoomUsers(roomId) {
+  const res = await http.get(`/chat/${roomId}/users`);
+  return res.data; // ResponseDTO<List<ChatUserResponseDTO>>
+}

--- a/frontend/src/features/chat/api/ChatRoomApi.js
+++ b/frontend/src/features/chat/api/ChatRoomApi.js
@@ -49,5 +49,7 @@ export async function createChatRoom(data) {
 // 채팅방 참여자 목록 조회 API
 export async function fetchChatRoomUsers(roomId) {
   const res = await http.get(`/chat/${roomId}/users`);
-  return res.data; // ResponseDTO<List<ChatUserResponseDTO>>
+  // ⭐ ResponseDTO 구조: { status: 200, message: "...", data: List<ChatUserResponseDTO> }
+  // 실제 리스트는 res.data.data에 있음
+  return res.data?.data || res.data || [];
 }

--- a/frontend/src/features/chat/components/ChatDetailPane.jsx
+++ b/frontend/src/features/chat/components/ChatDetailPane.jsx
@@ -9,10 +9,10 @@ import ChatMessageInputBox from "./ChatMessageInputBox";
 
 // 오른쪽 채팅방 상세패널(상단 Room, 메시지, 입력창)
 function ChatDetailPane({
-  selectedRoom, messages, userName,
-  unreadCount, firstUnreadIdx, formatTime,
+  selectedRoom, messages,
+  unreadCount, firstUnreadIdx, formatTime, // eslint-disable-line no-unused-vars
   inputRef, onSend, onFileUpload, socketConnected,
-  onScrollTop, isLoadingMore
+  onScrollTop, isLoadingMore, hasMoreAbove
 }) {
   const messagesEndRef = useRef(null);
 
@@ -60,13 +60,10 @@ function ChatDetailPane({
       </Box>
       <ChatMessageList
         messages={messages}
-        userName={userName}
         roomType={selectedRoom.roomType || "group"}
-        unreadCount={unreadCount}
-        firstUnreadIdx={firstUnreadIdx}
-        formatTime={formatTime}
-        onScrollTop={onScrollTop}
-        isLoadingMore={isLoadingMore}
+        onLoadMore={onScrollTop}
+        hasMoreAbove={hasMoreAbove}
+        loadingAbove={isLoadingMore}
       />
       <div ref={messagesEndRef} />
       <ChatMessageInputBox

--- a/frontend/src/features/chat/components/ChatDetailPane.jsx
+++ b/frontend/src/features/chat/components/ChatDetailPane.jsx
@@ -11,7 +11,8 @@ import ChatMessageInputBox from "./ChatMessageInputBox";
 function ChatDetailPane({
   selectedRoom, messages, userName,
   unreadCount, firstUnreadIdx, formatTime,
-  inputRef, onSend, onFileUpload, socketConnected
+  inputRef, onSend, onFileUpload, socketConnected,
+  onScrollTop, isLoadingMore
 }) {
   const messagesEndRef = useRef(null);
 
@@ -60,9 +61,12 @@ function ChatDetailPane({
       <ChatMessageList
         messages={messages}
         userName={userName}
+        roomType={selectedRoom.roomType || "group"}
         unreadCount={unreadCount}
         firstUnreadIdx={firstUnreadIdx}
         formatTime={formatTime}
+        onScrollTop={onScrollTop}
+        isLoadingMore={isLoadingMore}
       />
       <div ref={messagesEndRef} />
       <ChatMessageInputBox

--- a/frontend/src/features/chat/components/ChatDetailPane.jsx
+++ b/frontend/src/features/chat/components/ChatDetailPane.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { Box, Avatar, Typography, IconButton } from "@mui/material";
 import PhoneIcon from "@mui/icons-material/Phone";
 import VideoCallIcon from "@mui/icons-material/VideoCall";
@@ -6,6 +6,7 @@ import GroupIcon from "@mui/icons-material/Group";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import ChatMessageList from "./ChatMessageList";
 import ChatMessageInputBox from "./ChatMessageInputBox";
+import ChatRoomParticipantsDialog from "./ChatRoomParticipantsDialog";
 
 // 오른쪽 채팅방 상세패널(상단 Room, 메시지, 입력창)
 function ChatDetailPane({
@@ -15,6 +16,7 @@ function ChatDetailPane({
   onScrollTop, isLoadingMore, hasMoreAbove
 }) {
   const messagesEndRef = useRef(null);
+  const [participantsDialogOpen, setParticipantsDialogOpen] = useState(false);
 
   useEffect(() => {
     if (messagesEndRef.current) messagesEndRef.current.scrollIntoView({behavior: "smooth"});
@@ -54,7 +56,12 @@ function ChatDetailPane({
         }}>
           <IconButton><PhoneIcon /></IconButton>
           <IconButton><VideoCallIcon /></IconButton>
-          <IconButton><GroupIcon /></IconButton>
+          <IconButton
+            onClick={() => setParticipantsDialogOpen(true)}
+            title="참여자 목록"
+          >
+            <GroupIcon />
+          </IconButton>
           <IconButton><MoreVertIcon /></IconButton>
         </Box>
       </Box>
@@ -71,6 +78,13 @@ function ChatDetailPane({
         onSend={onSend}
         onFileUpload={onFileUpload}
         socketConnected={socketConnected}
+      />
+      
+      {/* 채팅방 참여자 목록 다이얼로그 */}
+      <ChatRoomParticipantsDialog
+        open={participantsDialogOpen}
+        onClose={() => setParticipantsDialogOpen(false)}
+        roomId={selectedRoom?.roomId || selectedRoom?.id}
       />
     </Box>
   );

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -1,12 +1,15 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useContext } from "react";
 import { Box, Typography, Link, Avatar } from "@mui/material";
+import { UserProfileContext } from "../../../App";
 
+// 첨부파일 유형 이미지 감지
 const isImageFile = (url = "") => {
   if (!url) return false;
   const cleanUrl = url.split("?")[0].toLowerCase();
   return /\.(png|jpe?g|gif|bmp|webp|svg)$/i.test(cleanUrl);
 };
 
+// 시간 포맷 변환 (예: "오후 02:26")
 const formatTime = (time) => {
   if (!time) return "";
   const date = new Date(time);
@@ -14,233 +17,294 @@ const formatTime = (time) => {
   return date.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
 };
 
-const MessageBubble = ({ children, isMine }) => (
-  <Box
-    sx={{
-      bgcolor: isMine ? "#ffe585" : "#f6f8fa",
-      borderRadius: 2,
-      px: 2,
-      py: 1.2,
-      maxWidth: 380,
-      minWidth: 120,
-      wordBreak: "break-word",
-      boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
-    }}
-  >
-    {children}
-  </Box>
-);
+function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbove, loadingAbove }) {
+  // 👇 로그인 정보 받기!
+  const { userProfile } = useContext(UserProfileContext) || {};
+  const userEmail = userProfile?.email;
+  
+  const scrollRef = useRef();
 
-function ChatMessageList({ messages, userName, roomType = "group", onScrollTop, isLoadingMore }) {
-  const scrollContainerRef = useRef(null);
-  const messagesStartRef = useRef(null);
-  const previousMessagesLengthRef = useRef(0);
-  const isScrollingToTopRef = useRef(false);
-  
-  // 스크롤 이벤트 핸들러
+  // 무한 스크롤(위로 올릴 때 loadMore)
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el || !onLoadMore || !hasMoreAbove || loadingAbove) return;
+    if (el.scrollTop <= 24) onLoadMore && onLoadMore();
+  };
+
+  // 새 메시지 오면 항상 맨 아래로 스크롤
   useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    
-    const handleScroll = () => {
-      // 스크롤이 맨 위에 가까워지면 이전 메시지 로딩
-      if (container.scrollTop < 50 && onScrollTop && !isLoadingMore) {
-        isScrollingToTopRef.current = true;
-        onScrollTop();
-      }
-    };
-    
-    container.addEventListener('scroll', handleScroll);
-    return () => container.removeEventListener('scroll', handleScroll);
-  }, [onScrollTop, isLoadingMore]);
-  
-  // 메시지가 추가/변경될 때 스크롤 위치 조정
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container || !messages) return;
-    
-    const currentLength = messages.length;
-    const previousLength = previousMessagesLengthRef.current;
-    
-    // 이전 메시지가 앞에 추가된 경우 (무한 스크롤)
-    if (currentLength > previousLength && isScrollingToTopRef.current) {
-      const previousScrollHeight = container.scrollHeight;
-      const previousScrollTop = container.scrollTop;
-      
-      // DOM 업데이트 후 스크롤 위치 복원
-      setTimeout(() => {
-        const newScrollHeight = container.scrollHeight;
-        const heightDifference = newScrollHeight - previousScrollHeight;
-        container.scrollTop = previousScrollTop + heightDifference;
-        isScrollingToTopRef.current = false;
-      }, 50);
-    } 
-    // 새 메시지가 뒤에 추가된 경우 (최신 메시지) 또는 첫 로딩
-    else if (currentLength !== previousLength) {
-      const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
-      if (isNearBottom || previousLength === 0) {
-        setTimeout(() => {
-          container.scrollTop = container.scrollHeight;
-        }, 100);
-      }
-    }
-    
-    previousMessagesLengthRef.current = currentLength;
+    const el = scrollRef.current;
+    if (el && messages.length > 0) el.scrollTop = el.scrollHeight;
   }, [messages]);
-  
-  // 메시지가 하나도 없는 경우: "아직 메시지가 없습니다" 안내
-  if (!messages || messages.length === 0) {
-    return (
-      <Box 
-        ref={scrollContainerRef}
-        sx={{ 
-          mb: 2, 
-          height: "calc(100vh - 200px)",
-          maxHeight: "600px",
-          overflowY: "auto",
-          display: "flex", 
-          alignItems: "center", 
-          justifyContent: "center" 
-        }}
-      >
-        <Typography sx={{ color: "text.disabled", fontSize: 16, textAlign: "center" }}>
-          아직 메시지가 없습니다.<br />
-          메시지를 입력해 대화를 시작해보세요.
-        </Typography>
-      </Box>
-    );
-  }
-  
+
   return (
-    <Box 
-      ref={scrollContainerRef}
-      sx={{ 
-        mb: 2, 
-        height: "calc(100vh - 200px)",
-        maxHeight: "600px",
+    <Box
+      ref={scrollRef}
+      onScroll={handleScroll}
+      sx={{
+        // 채팅 영역을 고정 높이로, 내부 스크롤 적용
+        height: "55vh",
+        maxHeight: 600,
         overflowY: "auto",
-        px: 2,
-        py: 1
+        background: "#fafbff",
+        px: 3,
+        pt: 2,
+        pb: 2,
       }}
     >
-      {isLoadingMore && (
-        <Box sx={{ textAlign: "center", py: 1 }}>
-          <Typography sx={{ color: "text.secondary", fontSize: 12 }}>이전 메시지 불러오는 중...</Typography>
-        </Box>
+      {/* 로딩 상태 표시 (무한스크롤용) */}
+      {loadingAbove && (
+        <Box sx={{ textAlign: "center", py: 1, color: "#889" }}>불러오는 중...</Box>
       )}
-      <div ref={messagesStartRef} />
-      {messages.map((msg, idx) => {
-        const isMine = msg.senderName === userName;
-        const displayName = msg.senderName || (isMine ? userName || "나" : "상대방");
 
-        const content = (
-          <MessageBubble isMine={isMine}>
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-              {msg.messageContent && (
-                <Typography sx={{ color: isMine ? "#1aaf54" : "#333" }}>
-                  {msg.messageContent}
-                </Typography>
-              )}
-              {msg.fileYn && msg.fileUrl && (
-                isImageFile(msg.fileUrl) ? (
-                  <Box
-                    component="img"
-                    src={msg.fileUrl}
-                    alt="첨부 이미지"
-                    sx={{
-                      width: "100%",
-                      maxWidth: 280,
-                      borderRadius: 1.5,
-                      border: "1px solid #e1e4eb",
-                      objectFit: "cover"
-                    }}
-                  />
-                ) : (
-                  <Box
-                    sx={{
-                      bgcolor: "#fff",
-                      border: "1px solid #d7dce6",
-                      borderRadius: 1.5,
-                      px: 1.5,
-                      py: 0.8
-                    }}
-                  >
-                    <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#4b4f61" }}>
-                      첨부 파일
+      {/* 메시지가 없을 때 안내 */}
+      {(!messages || messages.length === 0) ? (
+        <Box sx={{ minHeight: 320, display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <Typography sx={{ color: "text.disabled", fontSize: 16, textAlign: "center" }}>
+            아직 메시지가 없습니다.<br />
+            메시지를 입력해 대화를 시작해보세요.
+          </Typography>
+        </Box>
+      ) : (
+        // 메시지 목록 map
+        messages.map((msg, idx) => {
+          // ⭐ 내 메시지 판별 로직
+          // 1순위: senderEmail로 비교 (가장 정확함) - 백엔드에서 항상 포함하도록 수정됨
+          // 2순위: senderEmail이 없을 경우 senderId로 비교 (fallback - 비권장)
+          // 대소문자/공백 차이를 방지하기 위해 trim().toLowerCase() 적용
+          let isMine = false;
+          
+          if (msg.senderEmail && userEmail) {
+            // ✅ senderEmail이 있으면 이메일로 비교 (가장 정확한 방법)
+            // 백엔드에서 모든 메시지에 senderEmail을 명시적으로 설정하도록 수정됨
+            isMine = msg.senderEmail.trim().toLowerCase() === userEmail.trim().toLowerCase();
+          } else if (msg.senderId && userProfile) {
+            // ⚠️ Fallback: senderEmail이 없을 경우 senderId로 비교
+            // 주의: 이 방법은 덜 정확할 수 있으므로 백엔드에서 senderEmail을 항상 포함하도록 수정 필요
+            // userProfile.id 또는 userProfile.userId 등 사용 가능한 필드 확인 필요
+            const userId = userProfile.id || userProfile.userId;
+            if (userId) {
+              isMine = msg.senderId === userId;
+              console.warn("⚠️ senderEmail이 없어 senderId로 판별합니다 (fallback):", {
+                senderId: msg.senderId,
+                userId: userId,
+                senderName: msg.senderName,
+                senderEmail: msg.senderEmail
+              });
+            }
+          }
+          
+          // ⚠️ 디버깅용 콘솔 로그 (senderEmail이 없을 때만 출력)
+          // 백엔드 수정 후에는 이 로그가 나타나지 않아야 함
+          if (!msg.senderEmail) {
+            console.error("❌ MSG에 senderEmail이 없습니다! 백엔드 수정 필요:", {
+              senderName: msg.senderName,
+              senderEmail: msg.senderEmail,
+              senderId: msg.senderId,
+              userEmail: userEmail,
+              userProfile: userProfile,
+              isMine: isMine
+            });
+          }
+
+          // ========== 내가 보낸 메시지 (오른쪽, 이름 없음, 파란 테마) ==========
+          if (isMine) {
+            return (
+              <Box
+                key={msg.id ?? idx}
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-end",
+                  mb: 2,
+                  textAlign: "right",
+                }}
+              >
+                <Box
+                  sx={{
+                    // 밝은 파란색 배경, 파란색 글씨로 스타일링
+                    bgcolor: "#e3f2fd",
+                    color: "#1976d2",
+                    borderRadius: 2,
+                    px: 2,
+                    py: 1.2,
+                    maxWidth: 380,
+                    minWidth: 120,
+                    wordBreak: "break-word",
+                    boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
+                  }}
+                >
+                  {/* 메시지 내용 */}
+                  {msg.messageContent && (
+                    <Typography sx={{ color: "#1976d2" }}>
+                      {msg.messageContent}
                     </Typography>
-                    <Link
-                      href={msg.fileUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="hover"
-                      sx={{ fontSize: 13, wordBreak: "break-all", color: "#007fff" }}
-                    >
-                      {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
-                    </Link>
-                  </Box>
-                )
-              )}
-            </Box>
-          </MessageBubble>
-        );
+                  )}
 
-        if (isMine) {
+                  {/* 첨부파일(이미지/파일 링크, 색상은 유지) */}
+                  {msg.fileYn && msg.fileUrl && (
+                    isImageFile(msg.fileUrl) ? (
+                      <Box
+                        component="img"
+                        src={msg.fileUrl}
+                        alt="첨부 이미지"
+                        sx={{
+                          width: "100%",
+                          maxWidth: 280,
+                          borderRadius: 1.5,
+                          border: "1px solid #e1e4eb",
+                          objectFit: "cover",
+                          mt: 1
+                        }}
+                      />
+                    ) : (
+                      <Box
+                        sx={{
+                          bgcolor: "#fff",
+                          border: "1px solid #90caf9",
+                          borderRadius: 1.5,
+                          px: 1.5,
+                          py: 0.8,
+                          mt: 1
+                        }}
+                      >
+                        <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#1976d2" }}>
+                          첨부 파일
+                        </Typography>
+                        <Link
+                          href={msg.fileUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          sx={{ fontSize: 13, wordBreak: "break-all", color: "#1976d2" }}
+                        >
+                          {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
+                        </Link>
+                      </Box>
+                    )
+                  )}
+                </Box>
+
+                {/* 전송 시간 (하단) */}
+                <Typography sx={{ fontSize: 12, color: "#90caf9", mt: 0.5 }}>
+                  {formatTime(msg.sendAt)}
+                </Typography>
+              </Box>
+            );
+          }
+
+          // ========== 상대방 메시지 (왼쪽, 이름/프로필/회색 테마) ==========
           return (
             <Box
               key={msg.id ?? idx}
               sx={{
                 display: "flex",
-                flexDirection: "column",
-                alignItems: "flex-end",
+                alignItems: "flex-start",
+                gap: 1.5,
                 mb: 2,
-                textAlign: "right",
               }}
             >
-              <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#1aaf54", mb: 0.5 }}>
-                {displayName}
-              </Typography>
-              {content}
-              <Typography sx={{ fontSize: 12, color: "#b0b6ce", mt: 0.5 }}>
-                {formatTime(msg.sendAt)}
-              </Typography>
+              {/* 프로필 아바타 - user_profile_image_key에서 가져온 이미지 표시 */}
+              <Avatar
+                src={msg.senderProfileImageUrl ? msg.senderProfileImageUrl : undefined}
+                sx={{
+                  bgcolor: "#bdbdbd",
+                  width: 36,
+                  height: 36,
+                  fontSize: 16,
+                  fontWeight: 700,
+                  color: "#212121",
+                }}
+                imgProps={{
+                  onError: (e) => {
+                    // 이미지 로드 실패 시 fallback 처리
+                    e.target.style.display = 'none';
+                  }
+                }}
+              >
+                {(!msg.senderProfileImageUrl || msg.senderProfileImageUrl.trim() === '') && (msg.senderName?.[0]?.toUpperCase() || "?")}
+              </Avatar>
+
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+                {/* 이름(어두운 회색) */}
+                <Typography sx={{ fontSize: 13, fontWeight: 700, color: "#212121", mb: 0.5 }}>
+                  {msg.senderName}
+                  {roomType === "group" && msg.senderTitle ? ` (${msg.senderTitle})` : ""}
+                </Typography>
+
+                <Box
+                  sx={{
+                    bgcolor: "#f5f5f5",
+                    color: "#212121",
+                    borderRadius: 2,
+                    px: 2,
+                    py: 1.2,
+                    maxWidth: 380,
+                    minWidth: 120,
+                    wordBreak: "break-word",
+                    boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
+                  }}
+                >
+                  {/* 메시지 내용(어두운 회색) */}
+                  {msg.messageContent && (
+                    <Typography sx={{ color: "#212121" }}>
+                      {msg.messageContent}
+                    </Typography>
+                  )}
+
+                  {/* 첨부파일 (배경색은 유지) */}
+                  {msg.fileYn && msg.fileUrl && (
+                    isImageFile(msg.fileUrl) ? (
+                      <Box
+                        component="img"
+                        src={msg.fileUrl}
+                        alt="첨부 이미지"
+                        sx={{
+                          width: "100%",
+                          maxWidth: 280,
+                          borderRadius: 1.5,
+                          border: "1px solid #bdbdbd",
+                          objectFit: "cover",
+                          mt: 1
+                        }}
+                      />
+                    ) : (
+                      <Box
+                        sx={{
+                          bgcolor: "#eeeeee",
+                          border: "1px solid #ccc",
+                          borderRadius: 1.5,
+                          px: 1.5,
+                          py: 0.8,
+                          mt: 1
+                        }}
+                      >
+                        <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#212121" }}>
+                          첨부 파일
+                        </Typography>
+                        <Link
+                          href={msg.fileUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          sx={{ fontSize: 13, wordBreak: "break-all", color: "#1565c0" }}
+                        >
+                          {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
+                        </Link>
+                      </Box>
+                    )
+                  )}
+                </Box>
+
+                {/* 전송 시간 (하단) */}
+                <Typography sx={{ fontSize: 12, color: "#757575", mt: 0.5 }}>
+                  {formatTime(msg.sendAt)}
+                </Typography>
+              </Box>
             </Box>
           );
-        }
-
-        return (
-          <Box
-            key={msg.id ?? idx}
-            sx={{
-              display: "flex",
-              alignItems: "flex-start",
-              gap: 1.5,
-              mb: 2,
-            }}
-          >
-            <Avatar
-              sx={{
-                bgcolor: "#10c16d",
-                width: 36,
-                height: 36,
-                fontSize: 16,
-                fontWeight: 700,
-              }}
-            >
-              {displayName?.[0]?.toUpperCase() || "?"}
-            </Avatar>
-            <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
-              <Typography sx={{ fontSize: 13, fontWeight: 700, color: "#1f2a44", mb: 0.5 }}>
-                {displayName}
-                {roomType === "group" && msg.senderTitle ? ` (${msg.senderTitle})` : ""}
-              </Typography>
-              {content}
-              <Typography sx={{ fontSize: 12, color: "#b0b6ce", mt: 0.5 }}>
-                {formatTime(msg.sendAt)}
-              </Typography>
-            </Box>
-          </Box>
-        );
-      })}
+        })
+      )}
     </Box>
   );
 }

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -153,67 +153,92 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
               >
                 <Box
                   sx={{
-                    // 밝은 파란색 배경, 파란색 글씨로 스타일링
-                    bgcolor: "#e3f2fd",
-                    color: "#1976d2",
-                    borderRadius: 2,
-                    px: 2,
-                    py: 1.2,
-                    maxWidth: 380,
-                    minWidth: 120,
-                    wordBreak: "break-word",
-                    boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 1,
+                    width: "100%",
+                    justifyContent: "flex-end",
                   }}
                 >
-                  {/* 메시지 내용 */}
-                  {msg.messageContent && (
-                    <Typography sx={{ color: "#1976d2" }}>
-                      {msg.messageContent}
+                  {/* ⭐ 안읽은 사람 수 표시 (메시지 왼쪽) */}
+                  {msg.unreadCount != null && msg.unreadCount > 0 && (
+                    <Typography
+                      sx={{
+                        fontSize: 11,
+                        color: "#1976d2",
+                        fontWeight: 600,
+                        alignSelf: "flex-start",
+                        mt: 1.2,
+                      }}
+                    >
+                      {msg.unreadCount}
                     </Typography>
                   )}
+                  
+                  <Box
+                    sx={{
+                      // 밝은 파란색 배경, 파란색 글씨로 스타일링
+                      bgcolor: "#e3f2fd",
+                      color: "#1976d2",
+                      borderRadius: 2,
+                      px: 2,
+                      py: 1.2,
+                      maxWidth: 380,
+                      minWidth: 120,
+                      wordBreak: "break-word",
+                      boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
+                    }}
+                  >
+                    {/* 메시지 내용 */}
+                    {msg.messageContent && (
+                      <Typography sx={{ color: "#1976d2" }}>
+                        {msg.messageContent}
+                      </Typography>
+                    )}
 
-                  {/* 첨부파일(이미지/파일 링크, 색상은 유지) */}
-                  {msg.fileYn && msg.fileUrl && (
-                    isImageFile(msg.fileUrl) ? (
-                      <Box
-                        component="img"
-                        src={msg.fileUrl}
-                        alt="첨부 이미지"
-                        sx={{
-                          width: "100%",
-                          maxWidth: 280,
-                          borderRadius: 1.5,
-                          border: "1px solid #e1e4eb",
-                          objectFit: "cover",
-                          mt: 1
-                        }}
-                      />
-                    ) : (
-                      <Box
-                        sx={{
-                          bgcolor: "#fff",
-                          border: "1px solid #90caf9",
-                          borderRadius: 1.5,
-                          px: 1.5,
-                          py: 0.8,
-                          mt: 1
-                        }}
-                      >
-                        <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#1976d2" }}>
-                          첨부 파일
-                        </Typography>
-                        <Link
-                          href={msg.fileUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          underline="hover"
-                          sx={{ fontSize: 13, wordBreak: "break-all", color: "#1976d2" }}
+                    {/* 첨부파일(이미지/파일 링크, 색상은 유지) */}
+                    {msg.fileYn && msg.fileUrl && (
+                      isImageFile(msg.fileUrl) ? (
+                        <Box
+                          component="img"
+                          src={msg.fileUrl}
+                          alt="첨부 이미지"
+                          sx={{
+                            width: "100%",
+                            maxWidth: 280,
+                            borderRadius: 1.5,
+                            border: "1px solid #e1e4eb",
+                            objectFit: "cover",
+                            mt: 1
+                          }}
+                        />
+                      ) : (
+                        <Box
+                          sx={{
+                            bgcolor: "#fff",
+                            border: "1px solid #90caf9",
+                            borderRadius: 1.5,
+                            px: 1.5,
+                            py: 0.8,
+                            mt: 1
+                          }}
                         >
-                          {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
-                        </Link>
-                      </Box>
-                    )
-                  )}
+                          <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#1976d2" }}>
+                            첨부 파일
+                          </Typography>
+                          <Link
+                            href={msg.fileUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            underline="hover"
+                            sx={{ fontSize: 13, wordBreak: "break-all", color: "#1976d2" }}
+                          >
+                            {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
+                          </Link>
+                        </Box>
+                      )
+                    )}
+                  </Box>
                 </Box>
 
                 {/* 전송 시간 (하단) */}
@@ -307,7 +332,7 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
                 );
               })()}
 
-              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", flex: 1 }}>
                 {/* 이름(어두운 회색) */}
                 <Typography sx={{ fontSize: 13, fontWeight: 700, color: "#212121", mb: 0.5 }}>
                   {msg.senderName}
@@ -316,65 +341,89 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
 
                 <Box
                   sx={{
-                    bgcolor: "#f5f5f5",
-                    color: "#212121",
-                    borderRadius: 2,
-                    px: 2,
-                    py: 1.2,
-                    maxWidth: 380,
-                    minWidth: 120,
-                    wordBreak: "break-word",
-                    boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 1,
+                    width: "100%",
                   }}
                 >
-                  {/* 메시지 내용(어두운 회색) */}
-                  {msg.messageContent && (
-                    <Typography sx={{ color: "#212121" }}>
-                      {msg.messageContent}
-                    </Typography>
-                  )}
+                  <Box
+                    sx={{
+                      bgcolor: "#f5f5f5",
+                      color: "#212121",
+                      borderRadius: 2,
+                      px: 2,
+                      py: 1.2,
+                      maxWidth: 380,
+                      minWidth: 120,
+                      wordBreak: "break-word",
+                      boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.03)",
+                    }}
+                  >
+                    {/* 메시지 내용(어두운 회색) */}
+                    {msg.messageContent && (
+                      <Typography sx={{ color: "#212121" }}>
+                        {msg.messageContent}
+                      </Typography>
+                    )}
 
-                  {/* 첨부파일 (배경색은 유지) */}
-                  {msg.fileYn && msg.fileUrl && (
-                    isImageFile(msg.fileUrl) ? (
-                      <Box
-                        component="img"
-                        src={msg.fileUrl}
-                        alt="첨부 이미지"
-                        sx={{
-                          width: "100%",
-                          maxWidth: 280,
-                          borderRadius: 1.5,
-                          border: "1px solid #bdbdbd",
-                          objectFit: "cover",
-                          mt: 1
-                        }}
-                      />
-                    ) : (
-                      <Box
-                        sx={{
-                          bgcolor: "#eeeeee",
-                          border: "1px solid #ccc",
-                          borderRadius: 1.5,
-                          px: 1.5,
-                          py: 0.8,
-                          mt: 1
-                        }}
-                      >
-                        <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#212121" }}>
-                          첨부 파일
-                        </Typography>
-                        <Link
-                          href={msg.fileUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          underline="hover"
-                          sx={{ fontSize: 13, wordBreak: "break-all", color: "#1565c0" }}
+                    {/* 첨부파일 (배경색은 유지) */}
+                    {msg.fileYn && msg.fileUrl && (
+                      isImageFile(msg.fileUrl) ? (
+                        <Box
+                          component="img"
+                          src={msg.fileUrl}
+                          alt="첨부 이미지"
+                          sx={{
+                            width: "100%",
+                            maxWidth: 280,
+                            borderRadius: 1.5,
+                            border: "1px solid #bdbdbd",
+                            objectFit: "cover",
+                            mt: 1
+                          }}
+                        />
+                      ) : (
+                        <Box
+                          sx={{
+                            bgcolor: "#eeeeee",
+                            border: "1px solid #ccc",
+                            borderRadius: 1.5,
+                            px: 1.5,
+                            py: 0.8,
+                            mt: 1
+                          }}
                         >
-                          {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
-                        </Link>
-                      </Box>
-                    )
+                          <Typography sx={{ fontSize: 13, fontWeight: 600, mb: 0.5, color: "#212121" }}>
+                            첨부 파일
+                          </Typography>
+                          <Link
+                            href={msg.fileUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            underline="hover"
+                            sx={{ fontSize: 13, wordBreak: "break-all", color: "#1565c0" }}
+                          >
+                            {decodeURIComponent(msg.fileUrl.split("/").pop()?.split("?")[0] || "파일 다운로드")}
+                          </Link>
+                        </Box>
+                      )
+                    )}
+                  </Box>
+                  
+                  {/* ⭐ 안읽은 사람 수 표시 (메시지 오른쪽) */}
+                  {msg.unreadCount != null && msg.unreadCount > 0 && (
+                    <Typography
+                      sx={{
+                        fontSize: 11,
+                        color: "#1976d2",
+                        fontWeight: 600,
+                        alignSelf: "flex-start",
+                        mt: 1.2,
+                      }}
+                    >
+                      {msg.unreadCount}
+                    </Typography>
                   )}
                 </Box>
 

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -67,6 +67,14 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
         </Box>
       ) : (
         // 메시지 목록 map
+        // ⭐ 디버깅: 첫 번째 메시지의 구조 확인 (개발 중 확인용)
+        // messages.length > 0 && console.log("📨 [ChatMessageList] 첫 번째 메시지 구조:", {
+        //   전체메시지수: messages.length,
+        //   첫번째메시지: messages[0],
+        //   senderProfileImageUrl: messages[0]?.senderProfileImageUrl,
+        //   senderEmail: messages[0]?.senderEmail,
+        //   senderName: messages[0]?.senderName
+        // }),
         messages.map((msg, idx) => {
           // ⭐ 내 메시지 판별 로직
           // 1순위: senderEmail로 비교 (가장 정확함) - 백엔드에서 항상 포함하도록 수정됨
@@ -106,6 +114,29 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
               isMine: isMine
             });
           }
+          
+          // ⚠️ 디버깅용 콘솔 로그 (senderProfileImageUrl이 없거나 빈 문자열일 때 출력)
+          // 프로필 이미지가 제대로 설정되지 않았을 때 확인용
+          // 개발 중에만 활성화 (필요시 주석 해제)
+          // if (!msg.senderProfileImageUrl || msg.senderProfileImageUrl.trim() === '') {
+          //   console.warn("⚠️ MSG에 senderProfileImageUrl이 없거나 빈 문자열입니다:", {
+          //     senderName: msg.senderName,
+          //     senderEmail: msg.senderEmail,
+          //     senderProfileImageUrl: msg.senderProfileImageUrl,
+          //     senderId: msg.senderId,
+          //     messageId: msg.id,
+          //     전체메시지: msg,
+          //     note: "프로필 이미지가 없으면 기본 이니셜이 표시됩니다. DB의 user_profile_image_key를 확인하세요."
+          //   });
+          // } else {
+          //   // 프로필 이미지 URL이 있을 때도 확인 (개발 중)
+          //   console.log("✅ 프로필 이미지 URL 있음:", {
+          //     senderName: msg.senderName,
+          //     senderEmail: msg.senderEmail,
+          //     senderProfileImageUrl: msg.senderProfileImageUrl,
+          //     url길이: msg.senderProfileImageUrl.length
+          //   });
+          // }
 
           // ========== 내가 보낸 메시지 (오른쪽, 이름 없음, 파란 테마) ==========
           if (isMine) {
@@ -204,26 +235,77 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
                 mb: 2,
               }}
             >
-              {/* 프로필 아바타 - user_profile_image_key에서 가져온 이미지 표시 */}
-              <Avatar
-                src={msg.senderProfileImageUrl ? msg.senderProfileImageUrl : undefined}
-                sx={{
-                  bgcolor: "#bdbdbd",
-                  width: 36,
-                  height: 36,
-                  fontSize: 16,
-                  fontWeight: 700,
-                  color: "#212121",
-                }}
-                imgProps={{
-                  onError: (e) => {
-                    // 이미지 로드 실패 시 fallback 처리
-                    e.target.style.display = 'none';
-                  }
-                }}
-              >
-                {(!msg.senderProfileImageUrl || msg.senderProfileImageUrl.trim() === '') && (msg.senderName?.[0]?.toUpperCase() || "?")}
-              </Avatar>
+              {/* ⭐ 프로필 아바타 - user_profile_image_key에서 가져온 이미지 표시 */}
+              {/* 
+                프로필 이미지 표시 로직:
+                1. msg.senderProfileImageUrl이 유효한 URL이면 이미지 표시
+                2. 없거나 빈 문자열이면 기본 이니셜 표시
+                3. 이미지 로드 실패 시 자동으로 이니셜 표시
+              */}
+              {(() => {
+                // ⭐ 디버깅: 실제로 Avatar에 전달되는 URL 확인
+                const profileImageUrl = msg.senderProfileImageUrl && msg.senderProfileImageUrl.trim() !== '' 
+                  ? msg.senderProfileImageUrl 
+                  : undefined;
+                
+                // ⚠️ 디버깅 로그 (개발 중 확인용 - 필요시 주석 해제)
+                // console.log("💡 [ChatMessageList] Avatar src 설정:", {
+                //   senderName: msg.senderName,
+                //   senderEmail: msg.senderEmail,
+                //   senderProfileImageUrl: msg.senderProfileImageUrl,
+                //   profileImageUrl: profileImageUrl,
+                //   url타입: typeof profileImageUrl,
+                //   url길이: profileImageUrl?.length || 0,
+                //   url시작: profileImageUrl?.substring(0, 20) || "없음",
+                //   isCompleteUrl: profileImageUrl?.startsWith("http://") || profileImageUrl?.startsWith("https://"),
+                //   messageId: msg.id
+                // });
+                
+                return (
+                  <Avatar
+                    src={profileImageUrl}
+                    sx={{
+                      bgcolor: "#bdbdbd",
+                      width: 36,
+                      height: 36,
+                      fontSize: 16,
+                      fontWeight: 700,
+                      color: "#212121",
+                    }}
+                    imgProps={{
+                      onError: (e) => {
+                        // ⚠️ 이미지 로드 실패 시 fallback 처리 (이니셜 표시)
+                        // 이미지가 로드되지 않으면 Avatar의 children(이니셜)이 자동으로 표시됨
+                        e.target.style.display = 'none';
+                        console.error("❌ [ChatMessageList] 프로필 이미지 로드 실패:", {
+                          senderName: msg.senderName,
+                          senderEmail: msg.senderEmail,
+                          profileImageUrl: msg.senderProfileImageUrl,
+                          실제src값: e.target.src,
+                          messageId: msg.id,
+                          note: "이미지 URL을 브라우저에서 직접 열어보세요. 403 에러면 S3 권한 문제입니다."
+                        });
+                      },
+                      onLoad: () => {
+                        // ✅ 이미지 로드 성공 시 디버깅 로그
+                        console.log("✅ [ChatMessageList] 프로필 이미지 로드 성공:", {
+                          senderName: msg.senderName,
+                          profileImageUrl: msg.senderProfileImageUrl,
+                          실제로드된URL: profileImageUrl
+                        });
+                      }
+                    }}
+                  >
+                    {/* 
+                      프로필 이미지가 없거나 빈 문자열일 때 기본 이니셜 표시
+                      - senderName의 첫 글자를 대문자로 변환
+                      - senderName이 없으면 "?" 표시
+                    */}
+                    {(!msg.senderProfileImageUrl || msg.senderProfileImageUrl.trim() === '') && 
+                      (msg.senderName?.[0]?.toUpperCase() || "?")}
+                  </Avatar>
+                );
+              })()}
 
               <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
                 {/* 이름(어두운 회색) */}

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -333,11 +333,60 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
               })()}
 
               <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", flex: 1 }}>
-                {/* 이름(어두운 회색) */}
-                <Typography sx={{ fontSize: 13, fontWeight: 700, color: "#212121", mb: 0.5 }}>
-                  {msg.senderName}
-                  {roomType === "group" && msg.senderTitle ? ` (${msg.senderTitle})` : ""}
-                </Typography>
+                {/* 이름 / 직급 / 부서 - 한 줄에 표시 */}
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap", mb: 0.5 }}>
+                  <Typography sx={{ fontSize: 13, fontWeight: 700, color: "#212121", display: "inline-block" }}>
+                    {msg.senderName || "이름 없음"}
+                  </Typography>
+                  {msg.senderJobGrade && (
+                    <>
+                      <Typography sx={{ fontSize: 13, color: "#666", display: "inline-block" }}>/</Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: "text.secondary",
+                          bgcolor: "action.selected",
+                          px: 1,
+                          py: 0.25,
+                          borderRadius: 1,
+                          fontSize: 12,
+                          display: "inline-block",
+                        }}
+                      >
+                        {(() => {
+                          const gradeMap = {
+                            INTERN: "인턴",
+                            STAFF: "사원",
+                            ASSISTANT_MANAGER: "대리",
+                            MANAGER: "과장",
+                            DEPUTY_GENERAL_MANAGER: "차장",
+                            GENERAL_MANAGER: "부장",
+                            DIRECTOR: "이사",
+                            EXECUTIVE_DIRECTOR: "상무",
+                            VICE_PRESIDENT: "전무",
+                            PRESIDENT: "대표",
+                          };
+                          return gradeMap[msg.senderJobGrade] || msg.senderJobGrade;
+                        })()}
+                      </Typography>
+                    </>
+                  )}
+                  {msg.senderDeptName && (
+                    <>
+                      <Typography sx={{ fontSize: 13, color: "#666", display: "inline-block" }}>/</Typography>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: "primary.main",
+                          fontSize: 12,
+                          display: "inline-block",
+                        }}
+                      >
+                        {msg.senderDeptName}
+                      </Typography>
+                    </>
+                  )}
+                </Box>
 
                 <Box
                   sx={{

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -57,6 +57,7 @@ function getUserName() {
 
 export default function ChatLayout() {
   // ---------- 상태 변수 ----------
+  const { userProfile } = useContext(UserProfileContext) || {};
   const [roomList, setRoomList] = useState([]); // 전체 채팅방 목록
   const [selectedRoomId, setSelectedRoomId] = useState(null); // 현재 선택된 방ID
   const [messages, setMessages] = useState([]); // 현재 방 메시지 목록
@@ -162,7 +163,14 @@ export default function ChatLayout() {
 
   // ---------- 새 메시지 도착 처리 (+ 토스트 알림) ----------
   const handleNewMessage = (msg) => {
-    if (msg.senderName === userName) {
+    // senderEmail로 내 메시지 판단 (백엔드에서 senderEmail 포함)
+    // 대소문자/공백 차이를 방지하기 위해 trim().toLowerCase() 적용
+    const isMyMessage = 
+      msg.senderEmail && 
+      userProfile?.email && 
+      msg.senderEmail.trim().toLowerCase() === userProfile.email.trim().toLowerCase();
+    
+    if (isMyMessage) {
       if (Number(msg.roomId) === Number(selectedRoomId)) {
         setMessages((prev) => [...prev, msg]);
       }
@@ -408,7 +416,6 @@ export default function ChatLayout() {
             selectedRoom={Array.isArray(roomList)
               ? roomList.find(r => r && r.roomId === selectedRoomId) : null}
             messages={messages}
-            userName={userName}
             unreadCount={unreadCount}
             firstUnreadIdx={firstUnreadIdx}
             formatTime={formatTime}
@@ -418,6 +425,7 @@ export default function ChatLayout() {
             socketConnected={socketConnected}
             onScrollTop={handleLoadMoreMessages}
             isLoadingMore={isLoadingMore}
+            hasMoreAbove={hasMore}
           />
         </Box>
       </Box>

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -183,6 +183,15 @@ export default function ChatLayout() {
 
     if (!foundRoom) return;
     if (roomIdNum === Number(selectedRoomId)) {
+      // ⭐ 디버깅: 실시간 메시지 수신 시 프로필 이미지 URL 확인 (개발 중 확인용)
+      // console.log("📨 [ChatLayout] 실시간 메시지 수신:", {
+      //   senderName: msg.senderName,
+      //   senderEmail: msg.senderEmail,
+      //   senderProfileImageUrl: msg.senderProfileImageUrl,
+      //   profileImageUrl길이: msg.senderProfileImageUrl?.length || 0,
+      //   전체메시지: msg
+      // });
+      
       setMessages((prev) => [...prev, msg]);
     } else { // 다른 방이면 토스트 알림
       setToastRooms((prev) => {
@@ -307,6 +316,19 @@ export default function ChatLayout() {
           if (pageData && Array.isArray(pageData.content)) {
             // 최신 메시지부터 내림차순으로 받아오므로 역순으로 정렬하여 오름차순으로 표시
             const sortedMessages = [...pageData.content].reverse();
+            
+            // ⭐ 디버깅: 메시지 수신 시 프로필 이미지 URL 확인 (개발 중 확인용)
+            // console.log("📨 [ChatLayout] 메시지 로드 완료:", {
+            //   메시지수: sortedMessages.length,
+            //   첫번째메시지: sortedMessages[0],
+            //   프로필이미지URL들: sortedMessages.map(m => ({
+            //     senderName: m.senderName,
+            //     senderEmail: m.senderEmail,
+            //     senderProfileImageUrl: m.senderProfileImageUrl,
+            //     profileImageUrl길이: m.senderProfileImageUrl?.length || 0
+            //   }))
+            // });
+            
             setMessages(sortedMessages);
             setTotalPages(pageData.totalPages || 0);
             setHasMore(!pageData.last); // last가 false면 더 있음

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -548,7 +548,7 @@ export default function ChatLayout() {
   // ---------- 스크롤로 읽음 처리 ----------
   const handleScrollRead = async () => {
     if (selectedRoomId && messages.length > 0) {
-      await markRoomMessagesAsRead(selectedRoomId, accessToken);
+      await markRoomMessagesAsRead(selectedRoomId);
       loadRooms();
     }
   };
@@ -611,7 +611,7 @@ export default function ChatLayout() {
           // ⭐ 채팅방 접속 시 안읽은 메시지들을 읽음 처리
           // 이렇게 하면 내가 읽은 메시지들의 unreadCount가 -1씩 감소됨
           try {
-            await markRoomMessagesAsRead(selectedRoomId, accessToken);
+            await markRoomMessagesAsRead(selectedRoomId);
             console.log("[ChatLayout] 채팅방 접속 시 메시지 읽음 처리 완료 - roomId:", selectedRoomId);
           } catch (error) {
             console.error("[ChatLayout] 메시지 읽음 처리 실패:", error);
@@ -627,7 +627,7 @@ export default function ChatLayout() {
             
             // ⭐ 채팅방 접속 시 안읽은 메시지들을 읽음 처리
             try {
-              await markRoomMessagesAsRead(selectedRoomId, accessToken);
+              await markRoomMessagesAsRead(selectedRoomId);
               console.log("[ChatLayout] 채팅방 접속 시 메시지 읽음 처리 완료 - roomId:", selectedRoomId);
             } catch (error) {
               console.error("[ChatLayout] 메시지 읽음 처리 실패:", error);

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -163,6 +163,59 @@ export default function ChatLayout() {
 
   // ---------- 새 메시지 도착 처리 (+ 토스트 알림) ----------
   const handleNewMessage = (msg) => {
+    // ⭐ unreadCount 업데이트 메시지 처리 (다른 참여자가 메시지를 읽었을 때)
+    if (msg.type === "UNREAD_COUNT_UPDATE") {
+      const { chatId, unreadCount, roomId, viewerId, viewerEmail } = msg;
+      
+      // ⭐ 디버깅: UNREAD_COUNT_UPDATE 메시지 수신 확인 (필요시 주석 해제)
+      console.log("📊 [ChatLayout] UNREAD_COUNT_UPDATE 수신:", {
+        chatId,
+        unreadCount,
+        roomId,
+        selectedRoomId,
+        viewerId,
+        viewerEmail,
+        메시지전체: msg
+      });
+      
+      // ⭐ 현재 선택된 방의 메시지 목록에서 해당 메시지의 unreadCount 업데이트
+      // (다른 참여자가 메시지를 읽었을 때 모든 참여자의 화면에서 unreadCount가 -1씩 감소)
+      if (Number(roomId) === Number(selectedRoomId)) {
+        setMessages((prev) => {
+          // ⭐ 이전 상태에서 해당 메시지 찾기
+          const targetMessage = prev.find(m => Number(m.id) === Number(chatId));
+          const previousUnreadCount = targetMessage?.unreadCount;
+          
+          const updated = prev.map((m) =>
+            Number(m.id) === Number(chatId)
+              ? { ...m, unreadCount: unreadCount != null ? unreadCount : 0 }
+              : m
+          );
+          
+          // ⭐ 디버깅: 업데이트된 메시지 확인 (필요시 주석 해제)
+          console.log("📊 [ChatLayout] unreadCount 업데이트 완료:", {
+            chatId,
+            이전unreadCount: previousUnreadCount,
+            새로운unreadCount: unreadCount,
+            업데이트된메시지: updated.find(m => Number(m.id) === Number(chatId)),
+            전체메시지수: updated.length
+          });
+          
+          return updated;
+        });
+      } else {
+        // ⭐ 다른 방의 메시지인 경우 로그만 출력
+        console.log("📊 [ChatLayout] UNREAD_COUNT_UPDATE 수신 (다른 방):", {
+          chatId,
+          unreadCount,
+          roomId,
+          selectedRoomId
+        });
+      }
+      
+      return;
+    }
+    
     // senderEmail로 내 메시지 판단 (백엔드에서 senderEmail 포함)
     // 대소문자/공백 차이를 방지하기 위해 trim().toLowerCase() 적용
     const isMyMessage = 
@@ -172,16 +225,40 @@ export default function ChatLayout() {
     
     if (isMyMessage) {
       if (Number(msg.roomId) === Number(selectedRoomId)) {
-        setMessages((prev) => [...prev, msg]);
+        // ⭐ 내가 보낸 새 메시지의 unreadCount가 있으면 그대로 사용 (백엔드에서 실시간 계산된 값)
+        // unreadCount가 없거나 undefined인 경우 0으로 설정
+        const newMessage = {
+          ...msg,
+          unreadCount: msg.unreadCount != null ? msg.unreadCount : 0
+        };
+        
+        // ⭐ 디버깅: 내가 보낸 메시지의 unreadCount 확인 (필요시 주석 해제)
+        console.log("📨 [ChatLayout] 내가 보낸 메시지 수신:", {
+          messageId: msg.id,
+          unreadCount: newMessage.unreadCount,
+          messageContent: msg.messageContent,
+          메시지전체: newMessage
+        });
+        
+        setMessages((prev) => {
+          const updated = [...prev, newMessage];
+          console.log("📨 [ChatLayout] 내가 보낸 메시지 추가 완료:", {
+            messageId: msg.id,
+            unreadCount: newMessage.unreadCount,
+            전체메시지수: updated.length
+          });
+          return updated;
+        });
       }
       return;
     }
     const roomIdNum = Number(msg.roomId);
-    const foundRoom = Array.isArray(roomList)
+    const foundRoom = Array.isArray(roomList) 
       ? roomList.find(r => r && Number(r.roomId) === roomIdNum)
       : null;
 
-    if (!foundRoom) return;
+    // ⭐ 현재 선택된 방의 메시지인 경우, foundRoom이 없어도 메시지 추가
+    // (roomList가 아직 로드되지 않았거나 업데이트되지 않은 경우에도 메시지 수신 가능)
     if (roomIdNum === Number(selectedRoomId)) {
       // ⭐ 디버깅: 실시간 메시지 수신 시 프로필 이미지 URL 확인 (개발 중 확인용)
       // console.log("📨 [ChatLayout] 실시간 메시지 수신:", {
@@ -189,25 +266,54 @@ export default function ChatLayout() {
       //   senderEmail: msg.senderEmail,
       //   senderProfileImageUrl: msg.senderProfileImageUrl,
       //   profileImageUrl길이: msg.senderProfileImageUrl?.length || 0,
+      //   unreadCount: msg.unreadCount,
       //   전체메시지: msg
       // });
       
-      setMessages((prev) => [...prev, msg]);
-    } else { // 다른 방이면 토스트 알림
-      setToastRooms((prev) => {
-        const filtered = prev.filter(r => Number(r.roomId) !== roomIdNum);
-        const newToast = {
-          roomId: msg.roomId,
-          unreadCount: msg.unreadCount || 1,
-          lastUnreadMessageContent: msg.messageContent,
-          lastUnreadMessageSenderName: msg.senderName,
-          lastUnreadMessageTime: msg.sendAt,
-          roomName: foundRoom.roomName
-        };
-        return [...filtered, newToast].sort(
-          (a, b) => new Date(b.lastUnreadMessageTime) - new Date(a.lastUnreadMessageTime)
-        );
+      // ⭐ 다른 사람이 보낸 새 메시지의 unreadCount가 있으면 그대로 사용 (백엔드에서 실시간 계산된 값)
+      // unreadCount가 없거나 undefined인 경우 0으로 설정
+      const newMessage = {
+        ...msg,
+        unreadCount: msg.unreadCount != null ? msg.unreadCount : 0
+      };
+      
+      // ⭐ 디버깅: 다른 사람이 보낸 메시지의 unreadCount 확인 (필요시 주석 해제)
+      console.log("📨 [ChatLayout] 다른 사람이 보낸 메시지 수신:", {
+        messageId: msg.id,
+        senderName: msg.senderName,
+        senderEmail: msg.senderEmail,
+        unreadCount: newMessage.unreadCount,
+        messageContent: msg.messageContent,
+        메시지전체: newMessage
       });
+      
+      setMessages((prev) => {
+        const updated = [...prev, newMessage];
+        console.log("📨 [ChatLayout] 다른 사람이 보낸 메시지 추가 완료:", {
+          messageId: msg.id,
+          unreadCount: newMessage.unreadCount,
+          전체메시지수: updated.length
+        });
+        return updated;
+      });
+    } else { // 다른 방이면 토스트 알림
+      // ⭐ foundRoom이 없으면 토스트 알림을 생성하지 않음 (roomList에 방이 없을 수 있음)
+      if (foundRoom) {
+        setToastRooms((prev) => {
+          const filtered = prev.filter(r => Number(r.roomId) !== roomIdNum);
+          const newToast = {
+            roomId: msg.roomId,
+            unreadCount: msg.unreadCount || 1,
+            lastUnreadMessageContent: msg.messageContent,
+            lastUnreadMessageSenderName: msg.senderName,
+            lastUnreadMessageTime: msg.sendAt,
+            roomName: foundRoom.roomName
+          };
+          return [...filtered, newToast].sort(
+            (a, b) => new Date(b.lastUnreadMessageTime) - new Date(a.lastUnreadMessageTime)
+          );
+        });
+      }
     }
     // roomList의 해당 방 정보를 최신화하고 정렬
     setRoomList((prevRoomList) => {
@@ -333,10 +439,27 @@ export default function ChatLayout() {
             setTotalPages(pageData.totalPages || 0);
             setHasMore(!pageData.last); // last가 false면 더 있음
             setCurrentPage(0);
+            
+            // ⭐ 채팅방 접속 시 안읽은 메시지들을 읽음 처리
+            // 이렇게 하면 내가 읽은 메시지들의 unreadCount가 -1씩 감소됨
+            try {
+              await markRoomMessagesAsRead(selectedRoomId, accessToken);
+              console.log("[ChatLayout] 채팅방 접속 시 메시지 읽음 처리 완료 - roomId:", selectedRoomId);
+            } catch (error) {
+              console.error("[ChatLayout] 메시지 읽음 처리 실패:", error);
+            }
           } else if (Array.isArray(pageData)) {
             // 기존 형식 (배열) 지원
             setMessages(pageData);
             setHasMore(false);
+            
+            // ⭐ 채팅방 접속 시 안읽은 메시지들을 읽음 처리
+            try {
+              await markRoomMessagesAsRead(selectedRoomId, accessToken);
+              console.log("[ChatLayout] 채팅방 접속 시 메시지 읽음 처리 완료 - roomId:", selectedRoomId);
+            } catch (error) {
+              console.error("[ChatLayout] 메시지 읽음 처리 실패:", error);
+            }
           } else {
             setMessages([]);
             setHasMore(false);
@@ -403,6 +526,19 @@ export default function ChatLayout() {
   const messagesEndRef = useRef(null);
   useEffect(() => {
     if (messagesEndRef.current) messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+  
+  // ⭐ 디버깅: messages 상태 변경 추적 (필요시 주석 해제)
+  useEffect(() => {
+    console.log("📋 [ChatLayout] messages 상태 변경:", {
+      메시지수: messages.length,
+      unreadCount포함메시지: messages.filter(m => m.unreadCount != null && m.unreadCount > 0).map(m => ({
+        id: m.id,
+        unreadCount: m.unreadCount,
+        senderName: m.senderName
+      })),
+      전체메시지unreadCount: messages.map(m => ({ id: m.id, unreadCount: m.unreadCount }))
+    });
   }, [messages]);
 
   // ---------- 읽지 않은 메시지 계산 및 첫 unread 인덱스 ----------

--- a/frontend/src/features/email/components/MailSideBar.jsx
+++ b/frontend/src/features/email/components/MailSideBar.jsx
@@ -8,7 +8,8 @@ import StarBorderIcon from "@mui/icons-material/StarBorder";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useNavigate } from "react-router-dom";
 import { MailCountContext } from "../../../App";
-import { emptyTrash, fetchDraftCount } from "../api/emailApi"; // ★ fetchDraftCount 추가!
+import { emptyTrash } from "../api/emailApi";
+import MailWriteButton from "./ui/MailWriteButton";
 
 const MailSideBar = () => {
   const navigate = useNavigate();
@@ -74,21 +75,7 @@ const MailSideBar = () => {
         </IconButton>
       </Box>
       <Box sx={{ mb: 1 }}>
-        <Button
-          variant="outlined"
-          fullWidth
-          size="small"
-          onClick={() => navigate("/email/write")}
-          sx={{
-            fontWeight: 700,
-            borderRadius: 2,
-            bgcolor: "#f6f7fc",
-            borderColor: "#e1e3ea",
-            py: 1,
-          }}
-        >
-          메일쓰기
-        </Button>
+        <MailWriteButton />
       </Box>
       <Box sx={{ flex: 1, overflowY: "auto" }}>
         {/* 즐겨찾기 */}


### PR DESCRIPTION
구현 완료 사항
백엔드
ChatRepository: 페이징 쿼리 메서드 추가 (findChatsWithFilesByRoomIdPaged)
ChatRoomService: 페이징 메서드 추가
ChatMessageController: page, size 파라미터 추가, Page<ChatMessageResponseDTO> 반환
프론트엔드
ChatRoomApi: 페이징 파라미터 지원
ChatMessageList:
고정 높이 스크롤 컨테이너 설정 (height: calc(100vh - 200px), overflowY: auto)
스크롤 이벤트 리스너로 상단 근접 시 이전 메시지 로딩
스크롤 위치 유지 로직 (이전 메시지 로딩 시)
ChatLayout:
페이징 상태 관리 (currentPage, hasMore, isLoadingMore)
무한 스크롤 로직 (handleLoadMoreMessages)
최신 메시지부터 내림차순으로 받아와 오름차순으로 표시
채팅 화면에서 메시지가 많아도 높이를 넘지 않으며, 스크롤로 이전 메시지를 계속 불러올 수 있습니다. 스크롤이 상단에 가까워지면 자동으로 이전 메시지를 로딩하고, 로딩 중에는 "이전 메시지 불러오는 중..." 표시가 나타납니다.