### PR TITLE
메일 탭별 뱃지 개수와 실제 데이터 개수 일치시키기

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/controller/ChatMessageController.java
@@ -1063,6 +1063,32 @@ public class ChatMessageController {
         return ResponseEntity.ok(ResponseDTO.success(dtoList, "초대 및 참여 메시지 저장 성공"));
     }
     
+    // 11. 채팅방 나가기
+    @Operation(summary = "채팅방 나가기", description = "채팅방에서 나가고 나가기 메시지를 전송합니다.")
+    @org.springframework.web.bind.annotation.DeleteMapping("/{roomId}/leave")
+    @org.springframework.transaction.annotation.Transactional
+    public ResponseEntity<ResponseDTO<String>> leaveChatRoom(
+            @PathVariable("roomId") Integer roomId,
+            Principal principal
+    ) {
+        try {
+            String userEmail = principal.getName();
+            log.info("[leaveChatRoom] 채팅방 나가기 요청 - roomId: {}, userEmail: {}", roomId, userEmail);
+            
+            chatRoomService.leaveChatRoom(roomId, userEmail);
+            
+            log.info("[leaveChatRoom] 채팅방 나가기 성공 - roomId: {}, userEmail: {}", roomId, userEmail);
+            return ResponseEntity.ok(ResponseDTO.success("채팅방을 나갔습니다.", "채팅방 나가기 성공"));
+        } catch (IllegalArgumentException e) {
+            log.error("[leaveChatRoom] 채팅방 나가기 실패 - roomId: {}, error: {}", roomId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ResponseDTO.error("채팅방 나가기 실패: " + e.getMessage()));
+        } catch (Exception e) {
+            log.error("[leaveChatRoom] 채팅방 나가기 중 예외 발생 - roomId: {}", roomId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ResponseDTO.error("채팅방 나가기 중 오류가 발생했습니다: " + e.getMessage()));
+        }
+    }
 
     // 10. 알림 읽음 처리 (채팅/업무)
     @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRoomUserRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRoomUserRepository.java
@@ -2,6 +2,8 @@ package com.goodee.coreconnect.chat.repository;
 
 import java.util.List;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +22,8 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Inte
 	// 내가 참여한 모든 채팅방
 	@Query("SELECT cru FROM ChatRoomUser cru JOIN FETCH cru.chatRoom WHERE cru.user.id = :userId")
 	List<ChatRoomUser> findByUserId(@Param("userId") Integer userId);
+	
+	// 특정 채팅방의 특정 사용자 조회
+	@Query("SELECT cru FROM ChatRoomUser cru WHERE cru.chatRoom.id = :roomId AND cru.user.id = :userId")
+	Optional<ChatRoomUser> findByChatRoomIdAndUserId(@Param("roomId") Integer roomId, @Param("userId") Integer userId);
 }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
@@ -91,4 +91,7 @@ public interface ChatRoomService {
 
 	boolean existsByRoomId(Integer roomId);
 
+	// 채팅방 나가기
+	void leaveChatRoom(Integer roomId, String userEmail);
+
 }

--- a/backend/src/main/java/com/goodee/coreconnect/email/repository/EmailRecipientRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/email/repository/EmailRecipientRepository.java
@@ -24,18 +24,31 @@ public interface EmailRecipientRepository extends JpaRepository<EmailRecipient, 
 
     // 안읽은 메일 개수 (수신자 이메일, 읽음여부, 삭제되지 않은 것만)
     // emailReadYn이 false이거나 null인 경우를 안읽은 메일로 간주
+    // DRAFT, RESERVED 상태 제외 (실제 목록 조회와 동일한 조건)
     @Query("SELECT COUNT(r) FROM EmailRecipient r " +
            "WHERE r.emailRecipientAddress = :emailRecipientAddress " +
+           "AND r.emailRecipientType IN ('TO', 'CC', 'BCC') " +
            "AND (r.emailReadYn = false OR r.emailReadYn IS NULL) " +
-           "AND r.email.emailStatus NOT IN ('TRASH', 'DELETED') " +
+           "AND r.email.emailStatus NOT IN ('TRASH', 'DELETED', 'DRAFT', 'RESERVED') " +
            "AND (r.deleted IS NULL OR r.deleted = false)")
     int countUnreadInboxMails(
+        @Param("emailRecipientAddress") String emailRecipientAddress
+    );
+
+    // 받은 메일함 전체 개수 (수신자 이메일, 삭제되지 않은 것만, DRAFT/RESERVED 제외)
+    @Query("SELECT COUNT(r) FROM EmailRecipient r " +
+           "WHERE r.emailRecipientAddress = :emailRecipientAddress " +
+           "AND r.emailRecipientType IN ('TO', 'CC', 'BCC') " +
+           "AND r.email.emailStatus NOT IN ('TRASH', 'DELETED', 'DRAFT', 'RESERVED') " +
+           "AND (r.deleted IS NULL OR r.deleted = false)")
+    int countInboxMails(
         @Param("emailRecipientAddress") String emailRecipientAddress
     );
 
     // 중요 메일 개수 (수신자 이메일, 중요 표시된 메일, 삭제되지 않은 것만)
     @Query("SELECT COUNT(r) FROM EmailRecipient r " +
            "WHERE r.emailRecipientAddress = :emailRecipientAddress " +
+           "AND r.emailRecipientType IN ('TO', 'CC', 'BCC') " +
            "AND r.email.favoriteStatus = true " +
            "AND r.email.emailStatus = 'SENT' " +
            "AND r.email.emailStatus NOT IN ('TRASH', 'DELETED') " +

--- a/backend/src/main/java/com/goodee/coreconnect/email/repository/EmailRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/email/repository/EmailRepository.java
@@ -168,6 +168,15 @@ public interface EmailRepository extends JpaRepository<Email, Integer> {
         @Param("searchType") String searchType,
         @Param("keyword") String keyword
     );
+
+    // 발신한 중요 메일 개수
+    @Query("SELECT COUNT(e) FROM Email e " +
+           "WHERE e.senderId = :senderId " +
+           "AND e.favoriteStatus = true " +
+           "AND e.emailStatus NOT IN ('TRASH', 'DELETED')")
+    long countFavoriteSentMails(
+        @Param("senderId") Integer senderId
+    );
 }
 
 

--- a/backend/src/main/java/com/goodee/coreconnect/email/service/EmailServiceImpl.java
+++ b/backend/src/main/java/com/goodee/coreconnect/email/service/EmailServiceImpl.java
@@ -244,6 +244,21 @@ public class EmailServiceImpl implements EmailService {
 	    Boolean favoriteStatus = email.getFavoriteStatus();
 	    response.setFavoriteStatus(favoriteStatus != null && favoriteStatus);
 
+	    // 읽음 여부 설정 (viewerEmail에 해당하는 수신자의 읽음 상태)
+	    // 읽음 처리를 한 후 업데이트된 recipient의 상태를 반영
+	    if (myRecipientOpt.isPresent()) {
+	        EmailRecipient myRecipient = myRecipientOpt.get();
+	        // 읽음 처리를 했으므로 엔티티가 이미 업데이트되어 있음 (flush 했으므로 최신 상태)
+	        // 읽음 처리 후 업데이트된 상태를 반영
+	        Boolean readYn = myRecipient.getEmailReadYn();
+	        response.setEmailReadYn(readYn);
+	        log.info("getEmailDetail: 응답 DTO에 emailReadYn 설정 - emailId={}, viewerEmail={}, emailReadYn={}", 
+	                emailId, viewerEmail, readYn);
+	    } else {
+	        // 수신자가 아닌 경우 (발신자 등)
+	        response.setEmailReadYn(null);
+	    }
+
 	    // 첨부파일 조회 및 세팅
 	    files = emailFileRepository.findByEmail(email);
 	    List<EmailResponseDTO.AttachmentDTO> attachments = files.stream()

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,22 +1,33 @@
 # WebSocket 허용 Origin 설정 (쉼표로 구분하여 여러 Origin 지정 가능)
 # 환경 변수 WEBSOCKET_ALLOWED_ORIGINS로 오버라이드 가능
 # 예: http://localhost:5173,http://13.125.225.211,https://yourdomain.com
-app.websocket.allowed-origins=${WEBSOCKET_ALLOWED_ORIGINS}
+# ⭐ Spring Boot는 환경 변수를 자동으로 인식하므로, 환경 변수가 설정되어 있으면 자동으로 사용됩니다.
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+app.websocket.allowed-origins=http://localhost:5173
 
 # CORS 허용 Origin 설정 (쉼표로 구분하여 여러 Origin 지정 가능)
 # 환경 변수 CORS_ALLOWED_ORIGINS로 오버라이드 가능
 # 예: http://localhost:5173,http://13.125.225.211,https://yourdomain.com
-app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
+# ⭐ Spring Boot는 환경 변수를 자동으로 인식하므로, 환경 변수가 설정되어 있으면 자동으로 사용됩니다.
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+app.cors.allowed-origins=http://localhost:5173
 
 spring.application.name=coreconnect
 
 # database
-# Spring Boot는 SPRING_DATASOURCE_* 환경 변수를 자동으로 인식합니다.
+# ⭐ Spring Boot는 SPRING_DATASOURCE_* 환경 변수를 자동으로 인식합니다.
 # docker-compose.yml에서 SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD로 전달됩니다.
+# 환경 변수가 설정되어 있으면 자동으로 사용되고, 없으면 아래 기본값이 사용됩니다.
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+# 배포 환경에서는 docker-compose.yml의 환경 변수가 우선 적용됩니다.
+# Spring Boot는 환경 변수를 자동으로 인식하므로, 환경 변수가 설정되어 있으면 자동으로 사용됩니다.
+# 참고: Spring Boot는 SPRING_DATASOURCE_URL 환경 변수를 자동으로 spring.datasource.url로 매핑합니다.
+spring.datasource.url=jdbc:mysql://coreconnect-db.cfsuoeqewu8x.ap-northeast-2.rds.amazonaws.com:3306/db_coreconnect?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=admin
+# ⭐ 로컬 MySQL root 비밀번호를 설정하세요. 비밀번호가 없으면 빈 문자열로 두세요.
+# ⭐ 환경 변수 SPRING_DATASOURCE_PASSWORD로 오버라이드 가능합니다.
+spring.datasource.password=coreconnect
 
 # jpa
 spring.jpa.database=mysql
@@ -25,13 +36,15 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=none
 
 # S3 기본설정
-cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID}
-cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY}
-cloud.aws.region.static=${AWS_REGION}
-cloud.aws.s3.bucket=${AWS_BUCKET_NAME}
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID:}
+cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY:}
+cloud.aws.region.static=${AWS_REGION:ap-northeast-2}
+cloud.aws.s3.bucket=${AWS_BUCKET_NAME:}
 
 # SendGrid 메일 서버 설정
-sendgrid.api.key=${SENDGRID_API_KEY}
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+sendgrid.api.key=${SENDGRID_API_KEY:}
 sendgrid.from.email=no-reply@your-domain.com
 sendgrid.from.name=YourAppName
 
@@ -44,13 +57,16 @@ mybatis.configuration.map-underscore-to-camel-case=true
 spring.profiles.active=secure
 
 # JWT 설정
-jwt.secret=${JWT_SECRET_KEY}
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+# 주의: 배포 환경에서는 반드시 환경 변수로 설정해야 합니다!
+jwt.secret=${JWT_SECRET_KEY:your-local-dev-secret-key-change-in-production}
 
 # 이메일 설정
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=${MAIL_USERNAME}
-spring.mail.password=${MAIL_PASSWORD}
+# ⭐ 환경 변수가 없을 경우를 대비하여 기본값 제공 (로컬 개발용)
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
 
 # SMTP 인증 및 TLS 설정
 spring.mail.properties.mail.smtp.auth=true

--- a/env.example
+++ b/env.example
@@ -12,6 +12,8 @@
 MYSQL_HOST=mysql-container
 # MySQL 포트 (기본값: 3306)
 MYSQL_PORT=3306
+# MySQL 데이터베이스 이름
+MYSQL_DATABASE=coreconnect
 # MySQL 사용자명
 MYSQL_USER=root
 # MySQL 비밀번호

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -261,6 +261,7 @@ function App() {
     refreshInboxCount,
     unreadCount: unreadCount || 0,
     refreshUnreadCount,
+    setUnreadCountDirectly: setUnreadCount,
     draftCount: draftCount || 0,
     refreshDraftCount,
     favoriteCount: favoriteCount || 0,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Topbar from "./components/layout/Topbar/Topbar";
 import Sidebar from "./components/layout/Sidebar";
 import { getMyProfileInfo } from "./features/user/api/userAPI";
 import {
+  fetchInboxCount,
   fetchUnreadCount,
   fetchDraftbox,
   fetchFavoriteCount,
@@ -81,6 +82,7 @@ const themeOptions = {
 function App() {
   const [userProfile, setUserProfile] = useState(null);
 
+  const [inboxCount, setInboxCount] = useState(0);
   const [unreadCount, setUnreadCount] = useState(0);
   const [draftCount, setDraftCount] = useState(0);
   const [favoriteCount, setFavoriteCount] = useState(0);
@@ -125,6 +127,14 @@ function App() {
       localStorage.setItem("themeMode", newTheme);
     }
   };
+
+  // 받은메일함 전체 개수
+  const refreshInboxCount = useCallback(async () => {
+    const userEmail = userProfile?.email;
+    if (!userEmail) return;
+    const count = await fetchInboxCount(userEmail);
+    setInboxCount(count || 0);
+  }, [userProfile?.email]);
 
   // 받은메일함(안읽은)
   const refreshUnreadCount = useCallback(async () => {
@@ -221,9 +231,10 @@ function App() {
     }
   };
 
-  // 최초 마운트 시 개수 상태 동기화 (안읽은+임시보관+중요메일+채팅+알림)
+  // 최초 마운트 시 개수 상태 동기화 (받은메일함+안읽은+임시보관+중요메일+채팅+알림)
   useEffect(() => {
     if (userProfile?.email) {
+      refreshInboxCount();
       refreshUnreadCount();
       refreshDraftCount();
       refreshFavoriteCount();
@@ -246,13 +257,15 @@ function App() {
   // context value: count, set, refresh 함수
   // useMemo를 사용하여 항상 동일한 객체 참조를 유지하고, userProfile이 없어도 기본값 제공
   const mailCountContextValue = useMemo(() => ({
+    inboxCount: inboxCount || 0,
+    refreshInboxCount,
     unreadCount: unreadCount || 0,
     refreshUnreadCount,
     draftCount: draftCount || 0,
     refreshDraftCount,
     favoriteCount: favoriteCount || 0,
     refreshFavoriteCount,
-  }), [unreadCount, draftCount, favoriteCount, refreshUnreadCount, refreshDraftCount, refreshFavoriteCount]);
+  }), [inboxCount, unreadCount, draftCount, favoriteCount, refreshInboxCount, refreshUnreadCount, refreshDraftCount, refreshFavoriteCount]);
 
   const approvalCountContextValue = useMemo(() => ({
     approvalCount: approvalCount || 0,

--- a/frontend/src/features/chat/api/ChatRoomApi.js
+++ b/frontend/src/features/chat/api/ChatRoomApi.js
@@ -51,3 +51,9 @@ export async function fetchChatRoomUsers(roomId) {
   // 실제 리스트는 res.data.data에 있음
   return res.data?.data || res.data || [];
 }
+
+// 채팅방 나가기 API
+export async function leaveChatRoom(roomId) {
+  const res = await http.delete(`/chat/${roomId}/leave`);
+  return res.data;
+}

--- a/frontend/src/features/chat/components/ChatRoomListPane.jsx
+++ b/frontend/src/features/chat/components/ChatRoomListPane.jsx
@@ -4,7 +4,7 @@ import http from "../../../api/http"; // axios 인스턴스 불러오기
 
 // 채팅방 목록(좌측) & 탭
 function ChatRoomListPane({
-  tabIdx, setTabIdx, roomList, selectedRoomId, setSelectedRoomId, formatTime
+  tabIdx, setTabIdx, roomList, selectedRoomId, setSelectedRoomId, formatTime, highlightedRoomId
 }) {
   // 정렬 상태: 기본값은 최신 메시지부터 (내림차순)
   const sortOrder = 'desc';
@@ -135,7 +135,18 @@ function ChatRoomListPane({
                   py: 2.4,
                   px: 1.2,
                   minHeight: "64px",
-                  cursor: "pointer"
+                  cursor: "pointer",
+                  // 새로 생성된 방 하이라이팅
+                  ...(highlightedRoomId === room.roomId && {
+                    background: "#e3f2fd",
+                    borderLeft: "4px solid #1976d2",
+                    animation: "highlightPulse 2s ease-in-out",
+                    "@keyframes highlightPulse": {
+                      "0%": { background: "#e3f2fd" },
+                      "50%": { background: "#bbdefb" },
+                      "100%": { background: "#e3f2fd" }
+                    }
+                  })
                 }}
               >
                 <ListItemAvatar>

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1082,6 +1082,30 @@ export default function ChatLayout() {
     }
   }, []);
 
+  // ---------- 채팅방 나가기 핸들러 ----------
+  const handleLeaveRoom = useCallback(async (roomId) => {
+    try {
+      // WebSocket 연결 해제
+      await disconnectStomp();
+      
+      // 채팅방 목록에서 제거
+      setRoomList(prev => prev.filter(room => room.roomId !== roomId));
+      
+      // 선택된 채팅방 해제
+      if (selectedRoomId === roomId) {
+        setSelectedRoomId(null);
+        setMessages([]);
+      }
+      
+      // 채팅방 목록 새로고침
+      await loadRooms();
+      
+      console.log("[ChatLayout] 채팅방 나가기 완료 - roomId:", roomId);
+    } catch (error) {
+      console.error("[ChatLayout] 채팅방 나가기 처리 중 오류:", error);
+    }
+  }, [selectedRoomId, loadRooms]);
+
   // ---------- 채팅방 선택 핸들러 (안읽은 메시지가 있으면 읽음 처리) ----------
   const handleRoomSelect = useCallback(async (roomId) => {
     // 먼저 채팅방 선택 (즉시 UI 반영)
@@ -1813,6 +1837,7 @@ export default function ChatLayout() {
                 }
               }
             }}
+            onLeaveRoom={handleLeaveRoom}
           />
         </Box>
       </Box>

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -66,6 +66,7 @@ export default function ChatLayout() {
   const [tabIdx, setTabIdx] = useState(0); // 탭 인덱스
   const [toastRooms, setToastRooms] = useState([]); // 토스트 알림 Rooms
   const [createOpen, setCreateOpen] = useState(false); // 방 생성 다이얼로그 열림 여부
+  const [highlightedRoomId, setHighlightedRoomId] = useState(null); // 하이라이팅된 채팅방 ID
 
   const userName = getUserName(); // 유저명
   const accessToken = localStorage.getItem("accessToken"); // 엑세스토큰
@@ -209,10 +210,18 @@ export default function ChatLayout() {
         return sortRoomList(updated);
       });
 
+      // 새로 생성된 방 하이라이팅
+      setHighlightedRoomId(roomId);
+      // 5초 후 하이라이팅 제거
+      setTimeout(() => {
+        setHighlightedRoomId(null);
+      }, 5000);
+
       setSelectedRoomId(roomId); // 방 생성시에만 바로 진입
       setCreateOpen(false);
       // 목록 새로고침하여 최신 상태 유지 (백엔드에서 받은 데이터로 동기화)
-      setTimeout(() => loadRooms(), 500);
+      // 하이라이팅을 유지하기 위해 selectedRoomId를 보존
+      setTimeout(() => loadRooms(true, roomId), 500);
     } catch (error) {
       console.error("채팅방 생성 에러:", error);
       alert("채팅방 생성 에러: " + (error.message || "응답 데이터 없음"));
@@ -1737,6 +1746,7 @@ export default function ChatLayout() {
             setSelectedRoomId={handleRoomSelect}
             unreadRoomCount={unreadRoomCount}
             formatTime={formatTime}
+            highlightedRoomId={highlightedRoomId}
           />
           <ChatDetailPane
             selectedRoom={Array.isArray(roomList)

--- a/frontend/src/features/email/api/emailApi.js
+++ b/frontend/src/features/email/api/emailApi.js
@@ -21,6 +21,11 @@ export const fetchInbox = (
   return http.get('/email/inbox', { params });
 };
 
+// 받은메일함 전체 개수 조회 (Controller의 /email/inbox/count와 매칭)
+export const fetchInboxCount = (userEmail) =>
+  http.get('/email/inbox/count', { params: { userEmail } })
+    .then(res => res.data.data);
+
 // '안읽은 메일' 개수 조회 (Controller의 /email/inbox/unread-count와 매칭)
 export const fetchUnreadCount = (userEmail) =>
   http.get('/email/inbox/unread-count', { params: { userEmail } })

--- a/frontend/src/features/email/components/MailSideBar.jsx
+++ b/frontend/src/features/email/components/MailSideBar.jsx
@@ -15,12 +15,14 @@ const MailSideBar = () => {
   const { showSnack } = useSnackbarContext();
   const navigate = useNavigate();
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
-  // context 값 받아오기: draftCount, unreadCount, …, refreshDraftCount 등
+  // context 값 받아오기: inboxCount, draftCount, unreadCount, …, refreshDraftCount 등
   const mailCountContext = useContext(MailCountContext);
   const {
+    inboxCount = 0,
     draftCount = 0,
     unreadCount = 0,
     favoriteCount = 0,
+    refreshInboxCount = () => {},
     refreshDraftCount = () => {},
     refreshUnreadCount = () => {},
     refreshFavoriteCount = () => {},
@@ -57,6 +59,7 @@ const MailSideBar = () => {
     setConfirmDialogOpen(false);
     try {
       await emptyTrash();
+      refreshInboxCount();
       refreshDraftCount();
       refreshUnreadCount();
       showSnack("휴지통이 비워졌습니다.", 'success');
@@ -227,9 +230,9 @@ const MailSideBar = () => {
                   primary={
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                       <Typography variant="body2" sx={{ lineHeight: 1.5 }}>받은메일함</Typography>
-                      {unreadCount != null && unreadCount > 0 && (
+                      {inboxCount != null && inboxCount > 0 && (
                         <Badge
-                          badgeContent={unreadCount}
+                          badgeContent={inboxCount}
                           anchorOrigin={{
                             vertical: 'top',
                             horizontal: 'right',

--- a/frontend/src/features/email/pages/MailDetailPage.jsx
+++ b/frontend/src/features/email/pages/MailDetailPage.jsx
@@ -46,7 +46,7 @@ function MailDetailPage() {
   const { refreshUnreadCount } = useOutletContext();
   const { userProfile } = useContext(UserProfileContext) || {};
   const mailCountContext = useContext(MailCountContext);
-  const { refreshFavoriteCount } = mailCountContext || {};
+  const { refreshInboxCount, refreshFavoriteCount } = mailCountContext || {};
   const userEmail = userProfile?.email;
 
   
@@ -72,6 +72,9 @@ function MailDetailPage() {
           setTimeout(() => {
             if (refreshUnreadCount) {
               refreshUnreadCount(); // ★여기!
+            }
+            if (refreshInboxCount) {
+              refreshInboxCount(); // 받은 메일함 전체 개수도 새로고침
             }
           }, 100);
         })

--- a/frontend/src/features/email/pages/MailDetailPage.jsx
+++ b/frontend/src/features/email/pages/MailDetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { getEmailDetail, downloadAttachment, markMailAsRead, moveToTrash, toggleFavoriteStatus } from '../api/emailApi';
 import http from '../../../api/http';
 import JSZip from 'jszip';
@@ -13,11 +13,12 @@ import StarIcon from '@mui/icons-material/Star';
 import Star from '@mui/icons-material/Star';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
-import { useParams, useNavigate, useOutletContext } from 'react-router-dom';
+import { useParams, useNavigate, useOutletContext, useLocation } from 'react-router-dom';
 import { useContext } from "react";
 import { UserProfileContext, MailCountContext } from "../../../App";
 import ConfirmDialog from "../../../components/utils/ConfirmDialog";
 import { useSnackbarContext } from "../../../components/utils/SnackbarContext";
+import { UNREAD_REFRESH_FLAG, UNREAD_PENDING_IDS_KEY } from "../constants/storageKeys";
 
 // 파일 사이즈 변환
 function formatBytes(bytes) {
@@ -39,6 +40,7 @@ function getStatusLabel(emailStatus) {
 function MailDetailPage() {
   const { emailId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const { showSnack } = useSnackbarContext();
   const [mailDetail, setMailDetail] = useState(null);
   const [snack, setSnack] = useState({ open: false, severity: 'info', message: '' });
@@ -46,9 +48,37 @@ function MailDetailPage() {
   const { refreshUnreadCount } = useOutletContext();
   const { userProfile } = useContext(UserProfileContext) || {};
   const mailCountContext = useContext(MailCountContext);
-  const { refreshInboxCount, refreshFavoriteCount } = mailCountContext || {};
+  const { refreshInboxCount, refreshFavoriteCount, setUnreadCountDirectly } = mailCountContext || {};
   const userEmail = userProfile?.email;
+  const fromTab = location.state?.fromTab; // 어느 탭에서 왔는지 확인
 
+  const decrementSidebarUnread = useCallback(() => {
+    if (typeof setUnreadCountDirectly === "function") {
+      setUnreadCountDirectly(prev => Math.max(0, prev - 1));
+    }
+  }, [setUnreadCountDirectly]);
+
+  const markUnreadListNeedsRefresh = useCallback(() => {
+    sessionStorage.setItem(UNREAD_REFRESH_FLAG, 'true');
+  }, []);
+
+  const addPendingUnreadId = useCallback((id) => {
+    if (!id) return;
+    try {
+      const raw = sessionStorage.getItem(UNREAD_PENDING_IDS_KEY);
+      const arr = raw ? JSON.parse(raw) : [];
+      if (!Array.isArray(arr)) {
+        sessionStorage.setItem(UNREAD_PENDING_IDS_KEY, JSON.stringify([id]));
+        return;
+      }
+      if (!arr.includes(id)) {
+        arr.push(id);
+        sessionStorage.setItem(UNREAD_PENDING_IDS_KEY, JSON.stringify(arr));
+      }
+    } catch (err) {
+      console.error("[MailDetailPage] addPendingUnreadId error", err);
+    }
+  }, []);
   
   useEffect(() => {
   if (!emailId || !userEmail) return;
@@ -65,27 +95,99 @@ function MailDetailPage() {
       favoriteStatus: favoriteStatus
     });
 
-    if (data.readYn === false || data.readYn === null || data.readYn === undefined) {
+    // 백엔드의 getEmailDetail에서 이미 읽음 처리를 했으므로,
+    // 응답의 emailReadYn을 확인합니다.
+    // 백엔드에서 읽음 처리를 했으면 emailReadYn이 true로 반환되어야 합니다.
+    const isUnread = data.emailReadYn === false || data.emailReadYn === null || data.emailReadYn === undefined;
+    const wasReadByBackend = data.emailReadYn === true;
+    
+    console.log("[MailDetailPage] 읽음 상태 확인:", {
+      emailId,
+      emailReadYn: data.emailReadYn,
+      isUnread,
+      wasReadByBackend,
+      fromTab
+    });
+    
+    if (isUnread) {
+      // 백엔드에서 읽음 처리가 안 된 경우에만 프론트엔드에서 처리
+      console.log("[MailDetailPage] 백엔드에서 읽음 처리가 안 됨, 프론트엔드에서 처리");
       markMailAsRead(emailId, userEmail)
         .then(() => {
-          // DB 반영을 위한 짧은 대기 후 카운트 업데이트
+          decrementSidebarUnread();
+          if (fromTab === "unread") {
+            addPendingUnreadId(Number(emailId));
+            markUnreadListNeedsRefresh();
+          }
+          // DB 반영을 위한 대기 후 카운트 업데이트
           setTimeout(() => {
+            // useOutletContext에서 받은 refreshUnreadCount 호출
             if (refreshUnreadCount) {
-              refreshUnreadCount(); // ★여기!
+              refreshUnreadCount();
+            }
+            // mailCountContext의 refreshUnreadCount도 호출 (사이드바 뱃지 업데이트)
+            if (mailCountContext?.refreshUnreadCount) {
+              mailCountContext.refreshUnreadCount();
             }
             if (refreshInboxCount) {
               refreshInboxCount(); // 받은 메일함 전체 개수도 새로고침
             }
-          }, 100);
+            
+            // 안읽은 메일 탭에서 왔다면 목록 새로고침을 위한 이벤트 발생
+            if (fromTab === "unread") {
+              setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('refreshUnreadMailList'));
+              }, 300);
+            }
+          }, 500);
         })
         .catch(err => {
           console.error("markMailAsRead error in MailDetailPage:", err);
+          // 에러가 발생해도 안읽은 메일 탭에서 왔다면 이벤트 발생
+          if (fromTab === "unread") {
+            markUnreadListNeedsRefresh();
+            setTimeout(() => {
+              window.dispatchEvent(new CustomEvent('refreshUnreadMailList'));
+            }, 500);
+          }
         });
+    } else if (wasReadByBackend) {
+      // 백엔드에서 읽음 처리를 했으므로 카운트만 업데이트
+      console.log("[MailDetailPage] 백엔드에서 읽음 처리 완료, 카운트 업데이트");
+      setTimeout(() => {
+        // useOutletContext에서 받은 refreshUnreadCount 호출
+        if (refreshUnreadCount) {
+          refreshUnreadCount();
+        }
+        // mailCountContext의 refreshUnreadCount도 호출 (사이드바 뱃지 업데이트)
+        if (mailCountContext?.refreshUnreadCount) {
+          mailCountContext.refreshUnreadCount();
+        }
+        if (refreshInboxCount) {
+          refreshInboxCount(); // 받은 메일함 전체 개수도 새로고침
+        }
+        
+        // 안읽은 메일 탭에서 왔다면 목록 새로고침을 위한 이벤트 발생
+        if (fromTab === "unread") {
+          markUnreadListNeedsRefresh();
+          setTimeout(() => {
+            window.dispatchEvent(new CustomEvent('refreshUnreadMailList'));
+          }, 300);
+        }
+      }, 300); // 백엔드에서 이미 처리했으므로 짧은 대기 시간
+    } else {
+      // 이미 읽은 메일이지만 안읽은 메일 탭에서 왔다면 목록 새로고침 (상태 동기화)
+      if (fromTab === "unread") {
+        markUnreadListNeedsRefresh();
+        setTimeout(() => {
+          window.dispatchEvent(new CustomEvent('refreshUnreadMailList'));
+        }, 300);
+      }
     }
   }).catch(err => {
     console.error("[MailDetailPage] getEmailDetail error:", err);
   });
-}, [emailId, userEmail, refreshUnreadCount]);
+}, [emailId, userEmail, refreshUnreadCount, mailCountContext, refreshInboxCount, fromTab, decrementSidebarUnread, markUnreadListNeedsRefresh, addPendingUnreadId]);
 
 
   if (!mailDetail) return <div>Loading...</div>;
@@ -362,46 +464,93 @@ function MailDetailPage() {
         </Box>
         <Box sx={{ display: 'flex', alignItems: "center", flexWrap: "wrap", gap: 2, mb: 1 }}>
           <Typography fontWeight={600} fontSize={15}>받는사람:</Typography>
-          {(mailDetail.toRecipients || []).map(r => (
-            <Chip
-              label={`${r.emailRecipientAddress}${r.userDept ? ' / ' + r.userDept : ''}`}
-              key={r.emailRecipientId}
-              size="small"
-              sx={{ mr: 1 }}
-            />
-          ))}
+          {(() => {
+            // 이메일 주소 기준으로 중복 제거
+            const seen = new Set();
+            return (mailDetail.toRecipients || []).filter(r => {
+              const address = r.emailRecipientAddress?.toLowerCase();
+              if (seen.has(address)) {
+                return false;
+              }
+              seen.add(address);
+              return true;
+            }).map(r => (
+              <Chip
+                label={`${r.emailRecipientAddress}${r.userDept ? ' / ' + r.userDept : ''}`}
+                key={r.emailRecipientId}
+                size="small"
+                sx={{ mr: 1 }}
+              />
+            ));
+          })()}
         </Box>
-        {(mailDetail.ccRecipients || []).length > 0 && (
-          <Box sx={{ display: 'flex', alignItems: "center", flexWrap: "wrap", gap: 2, mb: 1 }}>
-            <Typography color="textSecondary" fontSize={15}>참조:</Typography>
-            {mailDetail.ccRecipients.map(r =>
-              <Chip
-                label={`${r.emailRecipientAddress}${r.userDept ? ' / ' + r.userDept : ''}`}
-                key={r.emailRecipientId}
-                size="small"
-                variant="outlined"
-                sx={{ mr: 1, color: "#90b2cc" }}
-              />
-            )}
-          </Box>
-        )}
-        {(mailDetail.bccRecipients || []).length > 0 && (
-          <Box sx={{ display: 'flex', alignItems: "center", flexWrap: "wrap", gap: 2, mb: 1 }}>
-            <Typography color="textSecondary" fontSize={15}>숨은참조:</Typography>
-            {mailDetail.bccRecipients.map(r =>
-              <Chip
-                label={`${r.emailRecipientAddress}${r.userDept ? ' / ' + r.userDept : ''}`}
-                key={r.emailRecipientId}
-                size="small"
-                variant="outlined"
-                sx={{ mr: 1, color: "#b09dcc" }}
-              />
-            )}
-          </Box>
-        )}
+        {(() => {
+          // 참조(CC) 중복 제거
+          const seen = new Set();
+          const uniqueCcRecipients = (mailDetail.ccRecipients || []).filter(r => {
+            const address = r.emailRecipientAddress?.toLowerCase();
+            if (seen.has(address)) {
+              return false;
+            }
+            seen.add(address);
+            return true;
+          });
+          return uniqueCcRecipients.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: "center", flexWrap: "wrap", gap: 2, mb: 1 }}>
+              <Typography color="textSecondary" fontSize={15}>참조:</Typography>
+              {uniqueCcRecipients.map(r =>
+                <Chip
+                  label={`${r.emailRecipientAddress}${r.userDept ? ' / ' + r.userDept : ''}`}
+                  key={r.emailRecipientId}
+                  size="small"
+                  variant="outlined"
+                  sx={{ mr: 1, color: "#90b2cc" }}
+                />
+              )}
+            </Box>
+          );
+        })()}
+        {(() => {
+          // 숨은참조(BCC) 중복 제거
+          const seen = new Set();
+          const uniqueBccRecipients = (mailDetail.bccRecipients || []).filter(r => {
+            const address = r.emailRecipientAddress?.toLowerCase();
+            if (seen.has(address)) {
+              return false;
+            }
+            seen.add(address);
+            return true;
+          });
+          return uniqueBccRecipients.length > 0 && (
+            <Box sx={{ display: 'flex', alignItems: "center", flexWrap: "wrap", gap: 2, mb: 1 }}>
+              <Typography color="textSecondary" fontSize={15}>숨은참조:</Typography>
+              {uniqueBccRecipients.map(r =>
+                <Chip
+                  label={`${r.emailRecipientAddress}${r.userDept ? ' / ' + r.userDept : ''}`}
+                  key={r.emailRecipientId}
+                  size="small"
+                  variant="outlined"
+                  sx={{ mr: 1, color: "#b09dcc" }}
+                />
+              )}
+            </Box>
+          );
+        })()}
         {/* 보낸 날짜 라인 */}
         <Box sx={{ mt: 0.5, mb: 2, color: "#777", fontSize: 14 }}>
-          보낸날짜: {mailDetail.sentTime ? (typeof mailDetail.sentTime === "string" ? new Date(mailDetail.sentTime).toLocaleString() : mailDetail.sentTime) : "-"}
+          보낸날짜: {mailDetail.sentTime ? (() => {
+            try {
+              const d = typeof mailDetail.sentTime === "string" ? new Date(mailDetail.sentTime) : mailDetail.sentTime;
+              const yyyy = d.getFullYear();
+              const mm = String(d.getMonth() + 1).padStart(2, "0");
+              const dd = String(d.getDate()).padStart(2, "0");
+              const HH = String(d.getHours()).padStart(2, "0");
+              const mi = String(d.getMinutes()).padStart(2, "0");
+              return `${yyyy}-${mm}-${dd} ${HH}:${mi}`;
+            } catch {
+              return "-";
+            }
+          })() : "-"}
         </Box>
         {/* === 첨부파일 영역 (파일명 표시/다운로드) === */}
         {(mailDetail.attachments && mailDetail.attachments.length > 0) && (

--- a/frontend/src/features/email/pages/MailFavoritePage.jsx
+++ b/frontend/src/features/email/pages/MailFavoritePage.jsx
@@ -9,7 +9,8 @@ import ReplyIcon from '@mui/icons-material/Reply';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ForwardIcon from '@mui/icons-material/Forward';
 import SyncIcon from '@mui/icons-material/Sync';
-import ViewListIcon from '@mui/icons-material/ViewList';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import StarIcon from '@mui/icons-material/Star';
 
 import { fetchFavoriteMails, moveToTrash, getEmailDetail, toggleFavoriteStatus } from '../api/emailApi';
@@ -314,7 +315,7 @@ const MailFavoritePage = () => {
     });
   };
 
-  // 날짜 포맷 (YYYY-MM-DD HH시 mm분 ss초)
+  // 날짜 포맷 (YYYY-MM-DD HH:mm)
   const formatSentTime = (sentTime) => {
     if (!sentTime) return '-';
     try {
@@ -324,8 +325,7 @@ const MailFavoritePage = () => {
       const dd = String(d.getDate()).padStart(2, "0");
       const HH = String(d.getHours()).padStart(2, "0");
       const mi = String(d.getMinutes()).padStart(2, "0");
-      const ss = String(d.getSeconds()).padStart(2, "0");
-      return `${yyyy}-${mm}-${dd} ${HH}시 ${mi}분 ${ss}초`;
+      return `${yyyy}-${mm}-${dd} ${HH}:${mi}`;
     } catch {
       return '-';
     }
@@ -404,8 +404,11 @@ const MailFavoritePage = () => {
 
           {/* 툴바 버튼들 */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, position: 'relative' }}>
-            <IconButton onClick={handleSortByDate} title={sortOrder === "asc" ? "내림차순 정렬" : "오름차순 정렬"}>
-              <ViewListIcon />
+            <IconButton 
+              onClick={handleSortByDate} 
+              title={sortOrder === "asc" ? "날짜순 내림차순 (최신순)" : "날짜순 오름차순 (오래된순)"}
+            >
+              {sortOrder === "asc" ? <ArrowDownwardIcon /> : <ArrowUpwardIcon />}
             </IconButton>
             <IconButton onClick={handleRefresh}>
               <SyncIcon />

--- a/frontend/src/features/email/pages/MailInboxPage.jsx
+++ b/frontend/src/features/email/pages/MailInboxPage.jsx
@@ -340,9 +340,12 @@ const MailInboxPage = () => {
       const count = await fetchUnreadCount(userEmail);
       const finalCount = count || 0;
       setUnreadCount(finalCount);
-      // 컨텍스트도 직접 업데이트하여 사이드바에 반영 (refreshUnreadCount 호출)
+      // 컨텍스트도 직접 업데이트하여 사이드바에 반영 (refreshUnreadCount, refreshInboxCount 호출)
       if (mailCountContext?.refreshUnreadCount) {
         await mailCountContext.refreshUnreadCount();
+      }
+      if (mailCountContext?.refreshInboxCount) {
+        await mailCountContext.refreshInboxCount();
       }
     } catch (err) {
       console.error("loadUnreadCount error:", err);
@@ -471,6 +474,10 @@ const MailInboxPage = () => {
       });
       await loadInbox();      // 새로고침: 이동한 항목 즉시 사라짐
       await loadUnreadCount();// 언리드카운트까지 새로고침
+      // 받은 메일함 전체 개수도 새로고침
+      if (mailCountContext?.refreshInboxCount) {
+        await mailCountContext.refreshInboxCount();
+      }
     } catch (err) {
       console.error('deleteSelected error', err);
       showSnack('메일 삭제 중 오류가 발생했습니다.', 'error');

--- a/frontend/src/features/email/pages/MailInboxPage.jsx
+++ b/frontend/src/features/email/pages/MailInboxPage.jsx
@@ -19,6 +19,7 @@ import { MailCountContext } from "../../../App"; // 메일 카운트 컨텍스�
 import { UserProfileContext } from "../../../App";
 import { useSnackbarContext } from "../../../components/utils/SnackbarContext";
 import ConfirmDialog from "../../../components/utils/ConfirmDialog";
+import { UNREAD_REFRESH_FLAG, UNREAD_PENDING_IDS_KEY } from "../constants/storageKeys";
 
 const MailInboxPage = () => {
   const { showSnack } = useSnackbarContext();
@@ -44,6 +45,7 @@ const MailInboxPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const mailCountContext = useContext(MailCountContext);
+  const setUnreadCountDirectly = mailCountContext?.setUnreadCountDirectly;
 
   // 쿼리파라미터에 따라 탭 상태 반영
   useEffect(() => {
@@ -72,6 +74,28 @@ const MailInboxPage = () => {
     }
   };
 
+  const loadPendingIdsFromStorage = () => {
+    try {
+      const raw = sessionStorage.getItem(UNREAD_PENDING_IDS_KEY);
+      if (!raw) return new Set();
+      const arr = JSON.parse(raw);
+      if (!Array.isArray(arr)) return new Set();
+      return new Set(arr.filter(id => typeof id === "number"));
+    } catch (err) {
+      console.error("[MailInboxPage] loadPendingIdsFromStorage error", err);
+      return new Set();
+    }
+  };
+
+  const persistPendingIds = () => {
+    const ids = Array.from(pendingReadIdsRef.current);
+    if (ids.length === 0) {
+      sessionStorage.removeItem(UNREAD_PENDING_IDS_KEY);
+    } else {
+      sessionStorage.setItem(UNREAD_PENDING_IDS_KEY, JSON.stringify(ids));
+    }
+  };
+
   // 받은메일함 목록 로딩
   const loadInbox = async (
     pageIdx = page,
@@ -83,8 +107,7 @@ const MailInboxPage = () => {
     if (!userEmail) {
       console.warn("[MailInboxPage] loadInbox: userEmail이 없어서 메일 목록을 불러오지 않습니다.", {
         userProfile,
-        userEmail,
-        userProfileContext
+        userEmail
       });
       setMails([]);
       setTotal(0);
@@ -134,9 +157,11 @@ const MailInboxPage = () => {
             }
           });
           pendingReadIdsRef.current = stillPending;
+          persistPendingIds();
         }
       } else if (pendingReadIdsRef.current.size > 0) {
         pendingReadIdsRef.current = new Set();
+        persistPendingIds();
       }
 
       const listForState = activeTab === "unread"
@@ -158,6 +183,14 @@ const MailInboxPage = () => {
       console.error("fetchInbox error", err);
       setMails([]);
       setTotal(0);
+    }
+  };
+
+  const decrementUnreadCounters = (count = 1) => {
+    if (!count || count <= 0) return;
+    setUnreadCount(prev => Math.max(0, prev - count));
+    if (typeof setUnreadCountDirectly === "function") {
+      setUnreadCountDirectly(prev => Math.max(0, prev - count));
     }
   };
 
@@ -306,7 +339,7 @@ const MailInboxPage = () => {
   useEffect(() => {
     loadInbox();
     // eslint-disable-next-line
-  }, [userEmail, page, size, tab, appliedKeyword, appliedSearchType]);
+  }, [userEmail, page, size, tab, appliedKeyword, appliedSearchType, location.key]);
 
   // 페이지 포커스 시 목록 새로고침 (뒤로가기 시 목록 업데이트)
   useEffect(() => {
@@ -314,6 +347,10 @@ const MailInboxPage = () => {
       if (userEmail && tab === "unread") {
         loadInbox();
         loadUnreadCount();
+        // 사이드바 뱃지도 업데이트
+        if (mailCountContext?.refreshUnreadCount) {
+          mailCountContext.refreshUnreadCount();
+        }
       }
     };
     window.addEventListener('focus', handleFocus);
@@ -326,12 +363,66 @@ const MailInboxPage = () => {
       if (!document.hidden && userEmail && tab === "unread") {
         loadInbox();
         loadUnreadCount();
+        // 사이드바 뱃지도 업데이트
+        if (mailCountContext?.refreshUnreadCount) {
+          mailCountContext.refreshUnreadCount();
+        }
       }
     };
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userEmail, tab]);
+
+  // 안읽은 메일 목록 새로고침 이벤트 리스너 (MailDetailPage에서 메일을 읽을 때 발생)
+  useEffect(() => {
+    pendingReadIdsRef.current = loadPendingIdsFromStorage();
+  }, []);
+
+  useEffect(() => {
+    const handleRefreshUnreadMailList = () => {
+      if (userEmail && tab === "unread") {
+        // DB 반영을 위한 대기 후 목록 새로고침 (대기 시간 증가)
+        setTimeout(async () => {
+          try {
+            await loadInbox(page, size, "unread");
+            await loadUnreadCount();
+            // 사이드바 뱃지도 업데이트
+            if (mailCountContext?.refreshUnreadCount) {
+              await mailCountContext.refreshUnreadCount();
+            }
+            // 받은 메일함 전체 개수도 업데이트
+            if (mailCountContext?.refreshInboxCount) {
+              await mailCountContext.refreshInboxCount();
+            }
+          } catch (err) {
+            console.error("handleRefreshUnreadMailList error:", err);
+          }
+        }, 800); // 500ms -> 800ms로 증가하여 DB 반영 시간 확보
+      }
+    };
+    
+    window.addEventListener('refreshUnreadMailList', handleRefreshUnreadMailList);
+    return () => window.removeEventListener('refreshUnreadMailList', handleRefreshUnreadMailList);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userEmail, tab, page, size]);
+
+  useEffect(() => {
+    if (tab !== "unread") return;
+    const shouldRefresh = sessionStorage.getItem(UNREAD_REFRESH_FLAG);
+    if (shouldRefresh === 'true') {
+      sessionStorage.removeItem(UNREAD_REFRESH_FLAG);
+      (async () => {
+        try {
+          await loadInbox(page, size, "unread");
+          await loadUnreadCount();
+        } catch (err) {
+          console.error("[MailInboxPage] unread refresh sync error", err);
+        }
+      })();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, location.key]);
 
   // 안읽은 개수 fetch + 컨텍스트 연동
   const loadUnreadCount = async () => {
@@ -415,10 +506,15 @@ const MailInboxPage = () => {
       const readPromises = unreadMails.map(mail => markMailAsRead(mail.emailId, userEmail));
       await Promise.all(readPromises);
 
+      if (unreadMails.length > 0) {
+        decrementUnreadCounters(unreadMails.length);
+      }
+
       // 안읽은 메일 탭인 경우 읽음 처리된 메일들을 목록에서 즉시 제거 (Optimistic Update)
       if (tab === "unread") {
         const readMailIds = new Set(unreadMails.map(m => m.emailId));
         readMailIds.forEach(id => pendingReadIdsRef.current.add(id));
+        persistPendingIds();
         setMails(prev => prev.filter(m => !readMailIds.has(m.emailId)));
         setTotal(prev => Math.max(0, prev - readMailIds.size));
       }
@@ -434,6 +530,10 @@ const MailInboxPage = () => {
           try {
             await loadInbox(page, size, "unread");
             await loadUnreadCount();
+            // 사이드바 뱃지 업데이트
+            if (mailCountContext?.refreshUnreadCount) {
+              await mailCountContext.refreshUnreadCount();
+            }
           } catch (err) {
             console.error("loadInbox error after mark as read", err);
           }
@@ -442,6 +542,10 @@ const MailInboxPage = () => {
         // 다른 탭에서는 안읽은 메일 개수만 업데이트
         setTimeout(async () => {
           await loadUnreadCount();
+          // 사이드바 뱃지 업데이트
+          if (mailCountContext?.refreshUnreadCount) {
+            await mailCountContext.refreshUnreadCount();
+          }
         }, 500);
       }
     } catch (err) {
@@ -484,7 +588,7 @@ const MailInboxPage = () => {
     }
   };
 
-  // 날짜 포맷 (YYYY-MM-DD HH시 mm분 ss초)
+  // 날짜 포맷 (YYYY-MM-DD HH:mm)
   const formatSentTime = (sentTime) => {
     if (!sentTime) return '-';
     try {
@@ -494,8 +598,7 @@ const MailInboxPage = () => {
       const dd = String(d.getDate()).padStart(2, "0");
       const HH = String(d.getHours()).padStart(2, "0");
       const mi = String(d.getMinutes()).padStart(2, "0");
-      const ss = String(d.getSeconds()).padStart(2, "0");
-      return `${yyyy}-${mm}-${dd} ${HH}시 ${mi}분 ${ss}초`;
+      return `${yyyy}-${mm}-${dd} ${HH}:${mi}`;
     } catch {
       return '-';
     }
@@ -515,6 +618,7 @@ const MailInboxPage = () => {
         // 안읽은 메일 탭에서 읽으면 목록에서 즉시 제거 (Optimistic Update)
         if (tab === "unread") {
           pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(mail.emailId);
+          persistPendingIds();
           setMails(prev => prev.filter(m => m.emailId !== mail.emailId));
           setTotal(prev => Math.max(0, prev - 1));
         }
@@ -527,6 +631,10 @@ const MailInboxPage = () => {
               // DB 반영 후 목록 새로고침 (안읽은 메일 필터 적용하여 서버와 동기화)
               await loadInbox(page, size, "unread");
               await loadUnreadCount();
+              // 사이드바 뱃지 업데이트
+              if (mailCountContext?.refreshUnreadCount) {
+                await mailCountContext.refreshUnreadCount();
+              }
             } catch (err) {
               console.error("loadInbox error after read", err);
             }
@@ -535,10 +643,14 @@ const MailInboxPage = () => {
           // 다른 탭에서는 안읽은 메일 개수만 업데이트
           setTimeout(async () => {
             await loadUnreadCount();
+            // 사이드바 뱃지 업데이트
+            if (mailCountContext?.refreshUnreadCount) {
+              await mailCountContext.refreshUnreadCount();
+            }
           }, 500);
         }
       }
-      navigate(`/email/${mail.emailId}`);   // 상세 페이지 이동
+      navigate(`/email/${mail.emailId}`, { state: { fromTab: tab } });   // 상세 페이지 이동 (현재 탭 정보 전달)
     } catch (err) {
       console.error("markMailAsRead error:", err);
       showSnack("메일 읽음처리 중 오류", 'error');

--- a/frontend/src/features/email/pages/MailReservedPage.jsx
+++ b/frontend/src/features/email/pages/MailReservedPage.jsx
@@ -212,10 +212,15 @@ const MailReservedPage = () => {
     try {
       if (!v) return "-";
       const d = new Date(v);
-      if (isNaN(d.getTime())) return v;
-      return d.toLocaleString();
+      if (isNaN(d.getTime())) return "-";
+      const yyyy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      const HH = String(d.getHours()).padStart(2, "0");
+      const mi = String(d.getMinutes()).padStart(2, "0");
+      return `${yyyy}-${mm}-${dd} ${HH}:${mi}`;
     } catch {
-      return v;
+      return "-";
     }
   };
 

--- a/frontend/src/features/email/pages/MailSentBoxPage.jsx
+++ b/frontend/src/features/email/pages/MailSentBoxPage.jsx
@@ -548,7 +548,19 @@ const MailSentBoxPage = () => {
                     )}
                   </TableCell>
                   <TableCell>
-                    {mail.sentTime ? new Date(mail.sentTime).toLocaleString() : "-"}
+                    {mail.sentTime ? (() => {
+                      try {
+                        const d = new Date(mail.sentTime);
+                        const yyyy = d.getFullYear();
+                        const mm = String(d.getMonth() + 1).padStart(2, "0");
+                        const dd = String(d.getDate()).padStart(2, "0");
+                        const HH = String(d.getHours()).padStart(2, "0");
+                        const mi = String(d.getMinutes()).padStart(2, "0");
+                        return `${yyyy}-${mm}-${dd} ${HH}:${mi}`;
+                      } catch {
+                        return "-";
+                      }
+                    })() : "-"}
                   </TableCell>
                   <TableCell align="right">
                     <Chip

--- a/frontend/src/features/email/pages/MailTrashPage.jsx
+++ b/frontend/src/features/email/pages/MailTrashPage.jsx
@@ -168,7 +168,7 @@ const MailTrashPage = () => {
     }
   };
 
-  // 날짜 포맷 함수
+  // 날짜 포맷 함수 (YYYY-MM-DD HH:mm)
   const formatSentTime = (sentTime) => {
     if (!sentTime) return '-';
     try {
@@ -178,8 +178,7 @@ const MailTrashPage = () => {
       const dd = String(d.getDate()).padStart(2, "0");
       const HH = String(d.getHours()).padStart(2, "0");
       const mi = String(d.getMinutes()).padStart(2, "0");
-      const ss = String(d.getSeconds()).padStart(2, "0");
-      return `${yyyy}-${mm}-${dd} ${HH}시 ${mi}분 ${ss}초`;
+      return `${yyyy}-${mm}-${dd} ${HH}:${mi}`;
     } catch {
       return '-';
     }


### PR DESCRIPTION
수정 내용 요약
백엔드 수정
받은 메일함 전체 개수 API 추가
EmailRecipientRepository.countInboxMails() 쿼리 추가
EmailController.getInboxCount() API 엔드포인트 추가
중요 메일 개수 계산 수정
수신한 중요 메일 + 발신한 중요 메일 포함
EmailRepository.countFavoriteSentMails() 쿼리 추가
EmailController.getFavoriteCount()에서 두 개수 합산
안읽은 메일 개수 쿼리 수정
DRAFT, RESERVED 상태 제외 (실제 목록 조회와 동일한 조건)
emailRecipientType IN ('TO', 'CC', 'BCC') 조건 추가
프론트엔드 수정
받은 메일함 뱃지 수정
안읽은 개수(unreadCount) 대신 전체 개수(inboxCount) 표시
fetchInboxCount() API 함수 추가
MailCountContext에 inboxCount와 refreshInboxCount 추가
개수 새로고침 로직 개선
메일 읽음/삭제 시 받은 메일함 전체 개수도 새로고침
MailInboxPage, MailDetailPage, MailSideBar에서 refreshInboxCount 호출 추가
이제 뱃지 개수가 실제 데이터 개수와 일치합니다:
받은 메일함: 전체 받은 메일 개수 표시
중요 메일: 수신 + 발신 중요 메일 개수 표시
안읽은 메일: DRAFT/RESERVED 제외한 안읽은 메일 개수 표시