### PR TITLE
안읽음 탭에서 안읽음 메시지가 있는 채팅방이 없습니다 표시

### DIFF
--- a/frontend/src/features/chat/components/ChatRoomListPane.jsx
+++ b/frontend/src/features/chat/components/ChatRoomListPane.jsx
@@ -111,7 +111,7 @@ function ChatRoomListPane({
             <ListItemText
               primary={
                 <Box sx={{ width: "100%", textAlign: "center", color: 'text.disabled', fontSize: 15 }}>
-                  {tabIdx === 1 ? "안읽은 메시지가 없습니다." : "채팅방을 생성해서 대화를 시작해보세요"}
+                  {tabIdx === 1 ? "안읽은 메시지가 있는 채팅방이 없습니다." : "채팅방을 생성해서 대화를 시작해보세요"}
                 </Box>
               }
             />


### PR DESCRIPTION
수정 완료.
안읽음 탭에서 안읽은 메시지가 있는 채팅방이 없을 때 "안읽은 메시지가 있는 채팅방이 없습니다."가 표시되도록 변경했습니다.
변경 사항:
안읽음 탭(tabIdx === 1)에서 filteredRooms.length === 0일 때 메시지를 "안읽은 메시지가 있는 채팅방이 없습니다."로 변경
전체 탭(tabIdx === 0)에서는 기존 메시지 유지