### PR TITLE
Backend에 healthcheck 추가: 8080 포트가 열릴 때까지 대기

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,15 @@ services:
     # 4) 컨테이너 간의 통신만 허용 (외부에서 8080으로 직접 접속할 수 없어 보안 향상)
     expose:
       - "8080"
-    # 5) docker-compose를 사용하면 Dockerfile를 통하지 않아도 환경 변수를 직접 컨테이너(boot-container)로 전달 가능
+    # 5) Healthcheck: Spring Boot 애플리케이션이 완전히 시작될 때까지 대기
+    # TCP 포트 체크로 8080 포트가 열려있는지 확인 (nc는 alpine 이미지에 기본 포함)
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 8080 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 90s
+    # 6) docker-compose를 사용하면 Dockerfile를 통하지 않아도 환경 변수를 직접 컨테이너(boot-container)로 전달 가능
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
@@ -42,9 +50,10 @@ services:
     # 4) boot-container와 동일한 도커 네트워크 사용
     networks:
       - my-network
-    # 5) backend 서비스 생성을 먼저할 것
+    # 5) backend 서비스가 완전히 준비될 때까지 대기
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
 
 # 외부 네트워크 사용 (도커 네트워크 my-network는 도커 컴포즈 실행 전에 미리 만들어 두어야 함)
 networks:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -27,6 +27,12 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Cookie $http_cookie;
     proxy_pass_request_headers on;
+    
+    # 연결 재시도 설정 (backend 준비 시간 고려)
+    proxy_connect_timeout 10s;
+    proxy_next_upstream error timeout http_502 http_503;
+    proxy_next_upstream_tries 3;
+    proxy_next_upstream_timeout 30s;
   }
 
   # WebSocket 프록시 (예: /ws/chat, /ws/notification 등 사용)
@@ -61,8 +67,11 @@ server {
     # 실시간 통신을 위해 버퍼링을 끄는 것이 필수
     proxy_buffering off;
     
-    # 연결 유지 설정
-    proxy_connect_timeout 60s;
+    # 연결 유지 설정 (backend 준비 시간 고려)
+    proxy_connect_timeout 10s;
+    proxy_next_upstream error timeout http_502 http_503;
+    proxy_next_upstream_tries 3;
+    proxy_next_upstream_timeout 30s;
     
     # 에러 페이지 설정 (선택사항)
     proxy_intercept_errors off;


### PR DESCRIPTION
수정 완료. 변경 사항 요약:
주요 수정 사항:
docker-compose.yml:
Backend에 healthcheck 추가: 8080 포트가 열릴 때까지 대기
Frontend의 depends_on에 condition: service_healthy 추가: Backend가 완전히 준비될 때까지 대기
nginx.conf:
/api와 /ws에 재시도 로직 추가
proxy_next_upstream 설정으로 backend가 준비되지 않았을 때 자동 재시도
proxy_connect_timeout을 10초로 설정
동작 방식:
Backend 컨테이너가 시작되면 healthcheck가 8080 포트가 열릴 때까지 확인
Healthcheck가 성공하면 Frontend 컨테이너가 시작됨
Nginx가 backend에 연결할 수 없으면 자동으로 재시도
참고:
nc (netcat) 명령어가 backend 이미지에 없으면 healthcheck가 실패할 수 있습니다
그 경우 backend Dockerfile에 nc 설치를 추가하거나, 다른 healthcheck 방법을 사용하세요