### PR TITLE
Fix CI/CD port 22 timeout issue

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,23 +67,70 @@ jobs:
       - name: Network Diagnostics
         run: |
           echo "🔍 네트워크 진단 시작..."
-          echo "📍 EC2 호스트 확인: ${{ secrets.EC2_HOST }}"
+          echo ""
+
+          # GitHub Actions Runner의 Public IP 확인
+          echo "📍 GitHub Actions Runner IP 주소:"
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "✅ Runner IP: $RUNNER_IP"
+          echo "⚠️ EC2 보안 그룹에서 이 IP를 SSH(22) 포트에 허용해야 합니다!"
+          echo ""
+
+          # EC2 호스트 확인
+          echo "📍 EC2 호스트: ${{ secrets.EC2_HOST }}"
+          echo ""
 
           # DNS 조회
           echo "🌐 DNS 조회:"
-          nslookup ${{ secrets.EC2_HOST }} || echo "⚠️ DNS 조회 실패"
+          if nslookup ${{ secrets.EC2_HOST }}; then
+            echo "✅ DNS 조회 성공"
+          else
+            echo "❌ DNS 조회 실패 - EC2_HOST가 올바른지 확인하세요"
+          fi
+          echo ""
 
           # Ping 테스트
           echo "🏓 Ping 테스트 (4회):"
-          ping -c 4 ${{ secrets.EC2_HOST }} || echo "⚠️ Ping 실패"
+          if ping -c 4 -W 5 ${{ secrets.EC2_HOST }}; then
+            echo "✅ Ping 성공 - 네트워크 연결 가능"
+          else
+            echo "❌ Ping 실패 - EC2 보안 그룹에서 ICMP를 차단 중이거나 인스턴스가 중지됨"
+          fi
+          echo ""
 
           # 포트 22 연결 테스트
           echo "🔌 포트 22 연결 테스트:"
-          timeout 10 bash -c "</dev/tcp/${{ secrets.EC2_HOST }}/22 && echo '✅ 포트 22 연결 가능'" || echo "❌ 포트 22 연결 불가"
+          if timeout 10 bash -c "cat < /dev/null > /dev/tcp/${{ secrets.EC2_HOST }}/22" 2>/dev/null; then
+            echo "✅ 포트 22 연결 가능!"
+          else
+            echo "❌ 포트 22 연결 불가!"
+            echo "원인 가능성:"
+            echo "  1. EC2 보안 그룹에서 SSH(22) 포트가 $RUNNER_IP 에 대해 차단됨"
+            echo "  2. EC2 인스턴스가 중지됨"
+            echo "  3. 네트워크 ACL 문제"
+            echo ""
+            echo "해결 방법:"
+            echo "  AWS Console → EC2 → 보안 그룹 → 인바운드 규칙"
+            echo "  - 유형: SSH, 포트: 22, 소스: $RUNNER_IP/32 또는 0.0.0.0/0"
+          fi
+          echo ""
 
           # Traceroute (경로 추적)
-          echo "🗺️ Traceroute:"
-          traceroute -m 10 ${{ secrets.EC2_HOST }} || echo "⚠️ Traceroute 실패"
+          echo "🗺️ Traceroute (최대 15홉):"
+          traceroute -m 15 -w 2 ${{ secrets.EC2_HOST }} || echo "⚠️ Traceroute 완료"
+          echo ""
+
+          # 최종 요약
+          echo "========================================="
+          echo "📊 진단 요약"
+          echo "========================================="
+          echo "Runner IP: $RUNNER_IP"
+          echo "EC2 Host: ${{ secrets.EC2_HOST }}"
+          echo ""
+          echo "다음 단계에서 SSH 연결이 실패하면:"
+          echo "1. EC2 보안 그룹에 Runner IP ($RUNNER_IP) 추가"
+          echo "2. 또는 임시로 0.0.0.0/0 허용 (테스트용)"
+          echo "========================================="
 
       # 3-3. SSH 연결 테스트 (디버깅용)
       - name: Test SSH Connection to EC2

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,7 +63,29 @@ jobs:
           echo "📝 EC2_HOST 값 확인 (마스킹됨): ${{ secrets.EC2_HOST }}"
           echo "📝 EC2_USER 값: ${{ secrets.EC2_USER }}"
       
-      # 3-2. SSH 연결 테스트 (디버깅용)
+      # 3-2. 네트워크 진단 (디버깅용)
+      - name: Network Diagnostics
+        run: |
+          echo "🔍 네트워크 진단 시작..."
+          echo "📍 EC2 호스트 확인: ${{ secrets.EC2_HOST }}"
+
+          # DNS 조회
+          echo "🌐 DNS 조회:"
+          nslookup ${{ secrets.EC2_HOST }} || echo "⚠️ DNS 조회 실패"
+
+          # Ping 테스트
+          echo "🏓 Ping 테스트 (4회):"
+          ping -c 4 ${{ secrets.EC2_HOST }} || echo "⚠️ Ping 실패"
+
+          # 포트 22 연결 테스트
+          echo "🔌 포트 22 연결 테스트:"
+          timeout 10 bash -c "</dev/tcp/${{ secrets.EC2_HOST }}/22 && echo '✅ 포트 22 연결 가능'" || echo "❌ 포트 22 연결 불가"
+
+          # Traceroute (경로 추적)
+          echo "🗺️ Traceroute:"
+          traceroute -m 10 ${{ secrets.EC2_HOST }} || echo "⚠️ Traceroute 실패"
+
+      # 3-3. SSH 연결 테스트 (디버깅용)
       - name: Test SSH Connection to EC2
         uses: appleboy/ssh-action@v1
         continue-on-error: true  # 실패해도 다음 단계 계속
@@ -72,7 +94,8 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
-          timeout: 60s
+          timeout: 120s
+          command_timeout: 5m
           debug: true
           script: |
             echo "✅ SSH 연결 테스트 성공!"
@@ -80,19 +103,69 @@ jobs:
             whoami
             echo "EC2 인스턴스에 정상적으로 연결되었습니다."
       
-      # 3-3. EC2로 파일 전송
-      - name: Copy file to EC2
+      # 3-4. EC2로 파일 전송 (재시도 로직 포함)
+      - name: Copy file to EC2 (Attempt 1)
+        id: scp-attempt-1
+        continue-on-error: true
         uses: appleboy/scp-action@v1
-        with: 
+        with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          port: 22  # SSH 포트 명시적으로 지정
-          timeout: 120s  # 타임아웃 120초로 증가
-          debug: true  # 디버그 모드 활성화
+          port: 22
+          timeout: 180s  # 타임아웃 3분으로 증가
+          command_timeout: 10m  # 명령 타임아웃 10분
+          debug: true
           source: "./*"
           target: "/home/ubuntu/website"
           rm: false
+          overwrite: true
+
+      - name: Wait before retry (if needed)
+        if: steps.scp-attempt-1.outcome == 'failure'
+        run: |
+          echo "⚠️ 첫 번째 SCP 시도 실패. 10초 후 재시도..."
+          sleep 10
+
+      - name: Copy file to EC2 (Attempt 2)
+        id: scp-attempt-2
+        if: steps.scp-attempt-1.outcome == 'failure'
+        continue-on-error: true
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          timeout: 240s  # 타임아웃 4분으로 증가
+          command_timeout: 15m
+          debug: true
+          source: "./*"
+          target: "/home/ubuntu/website"
+          rm: false
+          overwrite: true
+
+      - name: Wait before final retry (if needed)
+        if: steps.scp-attempt-2.outcome == 'failure'
+        run: |
+          echo "⚠️ 두 번째 SCP 시도 실패. 20초 후 최종 재시도..."
+          sleep 20
+
+      - name: Copy file to EC2 (Final Attempt)
+        if: steps.scp-attempt-2.outcome == 'failure'
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          timeout: 300s  # 타임아웃 5분으로 증가
+          command_timeout: 20m
+          debug: true
+          source: "./*"
+          target: "/home/ubuntu/website"
+          rm: false
+          overwrite: true
         
       # 4. EC2에서 Docker Compose 실행 (플러그인-https://github.com/appleboy/ssh-action)
       - name: Deploy with Docker Compose on EC2
@@ -102,7 +175,8 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22  # SSH 포트 명시적으로 지정
-          timeout: 120s  # 타임아웃 120초로 증가
+          timeout: 300s  # 타임아웃 5분으로 증가
+          command_timeout: 30m  # 명령 타임아웃 30분
           debug: true  # 디버그 모드 활성화
           script: |
             set -e  # 에러 발생 시 즉시 중단


### PR DESCRIPTION
- Add network diagnostics step (DNS lookup, ping, port test, traceroute)
- Increase SSH connection test timeout (60s -> 120s)
- Add retry logic for SCP action (3 attempts with exponential backoff)
- Increase SCP timeout progressively (180s -> 240s -> 300s)
- Increase Docker Compose deployment timeout (120s -> 300s)
- Add command_timeout parameters for long-running operations