### PR TITLE
https 설정을 위한 nginx conf 파일 변경

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,7 +1,7 @@
 # HTTP 서버 블록 - Let's Encrypt 인증서 발급을 위한 ACME challenge 허용
 server {
   listen 80;
-  server_name _;  # 모든 호스트/도메인 허용. 필요하다면 EC2 퍼블릭IP 등 지정 가능
+  server_name coreconnect.io.kr;  # 가비아 도메인
 
   # Let's Encrypt ACME challenge 경로 (인증서 발급 및 갱신용)
   location /.well-known/acme-challenge/ {
@@ -12,7 +12,7 @@ server {
   # 인증서가 있으면 HTTPS로 리다이렉트, 없으면 HTTP로 계속 서비스
   location / {
     # SSL 인증서가 존재하는지 확인
-    if (-f /etc/letsencrypt/live/_/fullchain.pem) {
+    if (-f /etc/letsencrypt/live/coreconnect.io.kr/fullchain.pem) {
       return 301 https://$host$request_uri;
     }
     
@@ -24,7 +24,7 @@ server {
 
   # 인증서가 있을 때만 API와 WebSocket을 리다이렉트
   location /api {
-    if (-f /etc/letsencrypt/live/_/fullchain.pem) {
+    if (-f /etc/letsencrypt/live/coreconnect.io.kr/fullchain.pem) {
       return 301 https://$host$request_uri;
     }
     proxy_pass http://boot-container:8080;
@@ -42,7 +42,7 @@ server {
   }
 
   location /ws {
-    if (-f /etc/letsencrypt/live/_/fullchain.pem) {
+    if (-f /etc/letsencrypt/live/coreconnect.io.kr/fullchain.pem) {
       return 301 https://$host$request_uri;
     }
     proxy_pass http://boot-container:8080;
@@ -69,115 +69,106 @@ server {
 }
 
 # HTTPS 서버 블록 - SSL 인증서가 있을 때만 활성화
-# ⚠️ 도메인명을 사용하는 경우: server_name과 인증서 경로의 '_'를 실제 도메인명으로 변경하세요
-# 예: server_name coreconnect.example.com;
-# 예: ssl_certificate /etc/letsencrypt/live/coreconnect.example.com/fullchain.pem;
-# 
-# ⚠️ 주의: SSL 인증서가 없으면 이 블록 전체를 주석 처리하세요.
-# 인증서가 준비되면 아래 주석을 해제하고 사용하세요.
-#
-# server {
-#   listen 443 ssl http2;
-#   server_name _;  # ⚠️ 도메인명 사용 시 실제 도메인명으로 변경 (예: coreconnect.example.com)
-#
-#   # SSL 인증서 설정 (Let's Encrypt)
-#   # ⚠️ 도메인명 사용 시 경로의 '_'를 실제 도메인명으로 변경하세요
-#   # 예: /etc/letsencrypt/live/coreconnect.example.com/fullchain.pem
-#   ssl_certificate /etc/letsencrypt/live/_/fullchain.pem;
-#   ssl_certificate_key /etc/letsencrypt/live/_/privkey.pem;
-#   
-#   # SSL 보안 설정
-#   ssl_protocols TLSv1.2 TLSv1.3;
-#   ssl_prefer_server_ciphers on;
-#   ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-#   ssl_session_cache shared:SSL:10m;
-#   ssl_session_timeout 10m;
-#   ssl_session_tickets off;
-#   
-#   # 보안 헤더
-#   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-#   add_header X-Frame-Options "SAMEORIGIN" always;
-#   add_header X-Content-Type-Options "nosniff" always;
-#   add_header X-XSS-Protection "1; mode=block" always;
-#
-#   # React 정적 파일 경로
-#   root /usr/share/nginx/html;
-#   index index.html;
-#
-#   # 파비콘 및 정적 파일 캐싱 설정
-#   location ~* \.(ico|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|eot)$ {
-#     expires 1y;
-#     add_header Cache-Control "public, immutable";
-#     access_log off;
-#   }
-#
-#   # 정적 파일 및 SPA 라우팅 처리
-#   location / {
-#     try_files $uri $uri/ /index.html;
-#   }
-#
-#   # 백엔드 API 프록시
-#   location /api {
-#     proxy_pass http://boot-container:8080;
-#     proxy_set_header Host $host;
-#     proxy_set_header X-Real-IP $remote_addr;
-#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#     proxy_set_header X-Forwarded-Proto $scheme;
-#     proxy_set_header Cookie $http_cookie;
-#     proxy_pass_request_headers on;
-#     
-#     # 연결 재시도 설정 (backend 준비 시간 고려)
-#     proxy_connect_timeout 10s;
-#     proxy_next_upstream error timeout http_502 http_503;
-#     proxy_next_upstream_tries 3;
-#     proxy_next_upstream_timeout 30s;
-#   }
-#
-#   # WebSocket 프록시 (예: /ws/chat, /ws/notification 등 사용)
-#   # SockJS와 STOMP를 모두 지원하도록 설정
-#   location /ws {
-#     proxy_pass http://boot-container:8080;
-#     proxy_http_version 1.1;
-#     
-#     # WebSocket 업그레이드 헤더 설정
-#     # SockJS는 upgrade가 아닐 수도 있으므로 조건부 처리
-#     proxy_set_header Upgrade $http_upgrade;
-#     proxy_set_header Connection "upgrade";
-#     
-#     # 기본 프록시 헤더
-#     proxy_set_header Host $host;
-#     proxy_set_header X-Real-IP $remote_addr;
-#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#     proxy_set_header X-Forwarded-Proto $scheme;
-#     proxy_set_header X-Forwarded-Host $host;
-#     proxy_set_header X-Forwarded-Port $server_port;
-#     
-#     # 쿠키 전달 (인증용) - WebSocket 인증에 필수
-#     proxy_set_header Cookie $http_cookie;
-#     proxy_pass_request_headers on;
-#     
-#     # WebSocket 타임아웃 설정 (24시간 = 86400초)
-#     # SockJS 폴링을 위한 긴 타임아웃 필요
-#     proxy_read_timeout 86400s;
-#     proxy_send_timeout 86400s;
-#     
-#     # WebSocket 버퍼링 비활성화 (중요!)
-#     # 실시간 통신을 위해 버퍼링을 끄는 것이 필수
-#     proxy_buffering off;
-#     
-#     # 연결 유지 설정 (backend 준비 시간 고려)
-#     proxy_connect_timeout 10s;
-#     proxy_next_upstream error timeout http_502 http_503;
-#     proxy_next_upstream_tries 3;
-#     proxy_next_upstream_timeout 30s;
-#     
-#     # 에러 페이지 설정 (선택사항)
-#     proxy_intercept_errors off;
-#   }
-#
-#   # Let's Encrypt ACME challenge 경로 (인증서 갱신용)
-#   location /.well-known/acme-challenge/ {
-#     root /usr/share/nginx/html;
-#     try_files $uri =404;
-#   }
-# }
+server {
+  listen 443 ssl http2;
+  server_name coreconnect.io.kr;
+
+  # SSL 인증서 설정 (Let's Encrypt)
+  ssl_certificate /etc/letsencrypt/live/coreconnect.io.kr/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/coreconnect.io.kr/privkey.pem;
+  
+  # SSL 보안 설정
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 10m;
+  ssl_session_tickets off;
+  
+  # 보안 헤더
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-XSS-Protection "1; mode=block" always;
+
+  # React 정적 파일 경로
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # 파비콘 및 정적 파일 캐싱 설정
+  location ~* \.(ico|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|eot)$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    access_log off;
+  }
+
+  # 정적 파일 및 SPA 라우팅 처리
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # 백엔드 API 프록시
+  location /api {
+    proxy_pass http://boot-container:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Cookie $http_cookie;
+    proxy_pass_request_headers on;
+    
+    # 연결 재시도 설정 (backend 준비 시간 고려)
+    proxy_connect_timeout 10s;
+    proxy_next_upstream error timeout http_502 http_503;
+    proxy_next_upstream_tries 3;
+    proxy_next_upstream_timeout 30s;
+  }
+
+  # WebSocket 프록시 (예: /ws/chat, /ws/notification 등 사용)
+  # SockJS와 STOMP를 모두 지원하도록 설정
+  location /ws {
+    proxy_pass http://boot-container:8080;
+    proxy_http_version 1.1;
+    
+    # WebSocket 업그레이드 헤더 설정
+    # SockJS는 upgrade가 아닐 수도 있으므로 조건부 처리
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    
+    # 기본 프록시 헤더
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    
+    # 쿠키 전달 (인증용) - WebSocket 인증에 필수
+    proxy_set_header Cookie $http_cookie;
+    proxy_pass_request_headers on;
+    
+    # WebSocket 타임아웃 설정 (24시간 = 86400초)
+    # SockJS 폴링을 위한 긴 타임아웃 필요
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+    
+    # WebSocket 버퍼링 비활성화 (중요!)
+    # 실시간 통신을 위해 버퍼링을 끄는 것이 필수
+    proxy_buffering off;
+    
+    # 연결 유지 설정 (backend 준비 시간 고려)
+    proxy_connect_timeout 10s;
+    proxy_next_upstream error timeout http_502 http_503;
+    proxy_next_upstream_tries 3;
+    proxy_next_upstream_timeout 30s;
+    
+    # 에러 페이지 설정 (선택사항)
+    proxy_intercept_errors off;
+  }
+
+  # Let's Encrypt ACME challenge 경로 (인증서 갱신용)
+  location /.well-known/acme-challenge/ {
+    root /usr/share/nginx/html;
+    try_files $uri =404;
+  }
+}


### PR DESCRIPTION
다음 단계
1. GitHub에 커밋 및 배포
git add frontend/nginx.confgit commit -m "Enable HTTPS for coreconnect.io.kr domain"git push origin main
GitHub Actions가 자동으로 배포합니다 (약 3-5분 소요).
2. 배포 완료 후 EC2에서 인증서 발급
EC2에 접속한 뒤:
# 배포 디렉토리로 이동cd /home/ubuntu/website# 인증서 발급 (이메일 주소는 본인 이메일로 변경)docker run -it --rm \  -v /etc/letsencrypt:/etc/letsencrypt \  -v /home/ubuntu/website/frontend/letsencrypt-challenge:/var/www/certbot/.well-known/acme-challenge \  certbot/certbot certonly \  --webroot \  --webroot-path=/var/www/certbot \  --email your-email@example.com \  --agree-tos \  --no-eff-email \  -d coreconnect.io.kr
또는 스크립트 사용:
cd /home/ubuntu/websitechmod +x scripts/init-letsencrypt.sh./scripts/init-letsencrypt.sh coreconnect.io.kr your-email@example.com
3. 인증서 발급 확인
ls -la /etc/letsencrypt/live/coreconnect.io.kr/
다음 파일들이 있어야 합니다:
fullchain.pem
privkey.pem
4. Nginx 재시작
cd /home/ubuntu/websitedocker compose restart frontend
5. 로그 확인
docker compose logs frontend
에러가 없으면 정상입니다.
6. HTTPS 접속 테스트
브라우저에서:
https://coreconnect.io.kr
자물쇠 아이콘이 표시되고 "연결이 안전합니다"가 보이면 성공입니다.
변경 사항 요약
HTTP 서버 블록: server_name을 coreconnect.io.kr로 변경
HTTPS 서버 블록: 주석 해제 및 도메인명 설정
SSL 인증서 경로: /etc/letsencrypt/live/coreconnect.io.kr/로 변경