### PR TITLE
인증서가 없어도 Nginx가 시작되도록 nginx.conf를 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .cursorrules
 .vscode/
 .env
+!.env.example
+!.env.template
 .txt

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -69,106 +69,109 @@ server {
 }
 
 # HTTPS 서버 블록 - SSL 인증서가 있을 때만 활성화
-server {
-  listen 443 ssl http2;
-  server_name coreconnect.io.kr;
-
-  # SSL 인증서 설정 (Let's Encrypt)
-  ssl_certificate /etc/letsencrypt/live/coreconnect.io.kr/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/coreconnect.io.kr/privkey.pem;
-  
-  # SSL 보안 설정
-  ssl_protocols TLSv1.2 TLSv1.3;
-  ssl_prefer_server_ciphers on;
-  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
-  ssl_session_cache shared:SSL:10m;
-  ssl_session_timeout 10m;
-  ssl_session_tickets off;
-  
-  # 보안 헤더
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-  add_header X-Frame-Options "SAMEORIGIN" always;
-  add_header X-Content-Type-Options "nosniff" always;
-  add_header X-XSS-Protection "1; mode=block" always;
-
-  # React 정적 파일 경로
-  root /usr/share/nginx/html;
-  index index.html;
-
-  # 파비콘 및 정적 파일 캐싱 설정
-  location ~* \.(ico|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|eot)$ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-    access_log off;
-  }
-
-  # 정적 파일 및 SPA 라우팅 처리
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
-  # 백엔드 API 프록시
-  location /api {
-    proxy_pass http://boot-container:8080;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Cookie $http_cookie;
-    proxy_pass_request_headers on;
-    
-    # 연결 재시도 설정 (backend 준비 시간 고려)
-    proxy_connect_timeout 10s;
-    proxy_next_upstream error timeout http_502 http_503;
-    proxy_next_upstream_tries 3;
-    proxy_next_upstream_timeout 30s;
-  }
-
-  # WebSocket 프록시 (예: /ws/chat, /ws/notification 등 사용)
-  # SockJS와 STOMP를 모두 지원하도록 설정
-  location /ws {
-    proxy_pass http://boot-container:8080;
-    proxy_http_version 1.1;
-    
-    # WebSocket 업그레이드 헤더 설정
-    # SockJS는 upgrade가 아닐 수도 있으므로 조건부 처리
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    
-    # 기본 프록시 헤더
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Forwarded-Port $server_port;
-    
-    # 쿠키 전달 (인증용) - WebSocket 인증에 필수
-    proxy_set_header Cookie $http_cookie;
-    proxy_pass_request_headers on;
-    
-    # WebSocket 타임아웃 설정 (24시간 = 86400초)
-    # SockJS 폴링을 위한 긴 타임아웃 필요
-    proxy_read_timeout 86400s;
-    proxy_send_timeout 86400s;
-    
-    # WebSocket 버퍼링 비활성화 (중요!)
-    # 실시간 통신을 위해 버퍼링을 끄는 것이 필수
-    proxy_buffering off;
-    
-    # 연결 유지 설정 (backend 준비 시간 고려)
-    proxy_connect_timeout 10s;
-    proxy_next_upstream error timeout http_502 http_503;
-    proxy_next_upstream_tries 3;
-    proxy_next_upstream_timeout 30s;
-    
-    # 에러 페이지 설정 (선택사항)
-    proxy_intercept_errors off;
-  }
-
-  # Let's Encrypt ACME challenge 경로 (인증서 갱신용)
-  location /.well-known/acme-challenge/ {
-    root /usr/share/nginx/html;
-    try_files $uri =404;
-  }
-}
+# ⚠️ 주의: SSL 인증서가 발급되기 전까지는 이 블록을 주석 처리해야 합니다.
+# 인증서 발급 후 아래 주석을 해제하고 사용하세요.
+#
+# server {
+#   listen 443 ssl http2;
+#   server_name coreconnect.io.kr;
+#
+#   # SSL 인증서 설정 (Let's Encrypt)
+#   ssl_certificate /etc/letsencrypt/live/coreconnect.io.kr/fullchain.pem;
+#   ssl_certificate_key /etc/letsencrypt/live/coreconnect.io.kr/privkey.pem;
+#   
+#   # SSL 보안 설정
+#   ssl_protocols TLSv1.2 TLSv1.3;
+#   ssl_prefer_server_ciphers on;
+#   ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#   ssl_session_cache shared:SSL:10m;
+#   ssl_session_timeout 10m;
+#   ssl_session_tickets off;
+#   
+#   # 보안 헤더
+#   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+#   add_header X-Frame-Options "SAMEORIGIN" always;
+#   add_header X-Content-Type-Options "nosniff" always;
+#   add_header X-XSS-Protection "1; mode=block" always;
+#
+#   # React 정적 파일 경로
+#   root /usr/share/nginx/html;
+#   index index.html;
+#
+#   # 파비콘 및 정적 파일 캐싱 설정
+#   location ~* \.(ico|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|eot)$ {
+#     expires 1y;
+#     add_header Cache-Control "public, immutable";
+#     access_log off;
+#   }
+#
+#   # 정적 파일 및 SPA 라우팅 처리
+#   location / {
+#     try_files $uri $uri/ /index.html;
+#   }
+#
+#   # 백엔드 API 프록시
+#   location /api {
+#     proxy_pass http://boot-container:8080;
+#     proxy_set_header Host $host;
+#     proxy_set_header X-Real-IP $remote_addr;
+#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     proxy_set_header X-Forwarded-Proto $scheme;
+#     proxy_set_header Cookie $http_cookie;
+#     proxy_pass_request_headers on;
+#     
+#     # 연결 재시도 설정 (backend 준비 시간 고려)
+#     proxy_connect_timeout 10s;
+#     proxy_next_upstream error timeout http_502 http_503;
+#     proxy_next_upstream_tries 3;
+#     proxy_next_upstream_timeout 30s;
+#   }
+#
+#   # WebSocket 프록시 (예: /ws/chat, /ws/notification 등 사용)
+#   # SockJS와 STOMP를 모두 지원하도록 설정
+#   location /ws {
+#     proxy_pass http://boot-container:8080;
+#     proxy_http_version 1.1;
+#     
+#     # WebSocket 업그레이드 헤더 설정
+#     # SockJS는 upgrade가 아닐 수도 있으므로 조건부 처리
+#     proxy_set_header Upgrade $http_upgrade;
+#     proxy_set_header Connection "upgrade";
+#     
+#     # 기본 프록시 헤더
+#     proxy_set_header Host $host;
+#     proxy_set_header X-Real-IP $remote_addr;
+#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     proxy_set_header X-Forwarded-Proto $scheme;
+#     proxy_set_header X-Forwarded-Host $host;
+#     proxy_set_header X-Forwarded-Port $server_port;
+#     
+#     # 쿠키 전달 (인증용) - WebSocket 인증에 필수
+#     proxy_set_header Cookie $http_cookie;
+#     proxy_pass_request_headers on;
+#     
+#     # WebSocket 타임아웃 설정 (24시간 = 86400초)
+#     # SockJS 폴링을 위한 긴 타임아웃 필요
+#     proxy_read_timeout 86400s;
+#     proxy_send_timeout 86400s;
+#     
+#     # WebSocket 버퍼링 비활성화 (중요!)
+#     # 실시간 통신을 위해 버퍼링을 끄는 것이 필수
+#     proxy_buffering off;
+#     
+#     # 연결 유지 설정 (backend 준비 시간 고려)
+#     proxy_connect_timeout 10s;
+#     proxy_next_upstream error timeout http_502 http_503;
+#     proxy_next_upstream_tries 3;
+#     proxy_next_upstream_timeout 30s;
+#     
+#     # 에러 페이지 설정 (선택사항)
+#     proxy_intercept_errors off;
+#   }
+#
+#   # Let's Encrypt ACME challenge 경로 (인증서 갱신용)
+#   location /.well-known/acme-challenge/ {
+#     root /usr/share/nginx/html;
+#     try_files $uri =404;
+#   }
+# }


### PR DESCRIPTION
변경 사항
HTTPS 서버 블록(443 포트)을 주석 처리
HTTP 서버 블록(80 포트)만 활성화
SSL 인증서 없이도 Nginx가 시작됨