### PR TITLE
nginx conf 수정

### DIFF
--- a/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
@@ -325,3 +325,4 @@ public class JMeterResultAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
@@ -333,3 +333,4 @@ public class MetricsAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
@@ -97,3 +97,4 @@ class PerformanceMetricsTest {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceReportGenerator.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceReportGenerator.java
@@ -184,3 +184,4 @@ public class PerformanceReportGenerator {
 
 
 
+

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -73,7 +73,8 @@ server {
 # 인증서 발급 후 아래 주석을 해제하고 사용하세요.
 #
 # server {
-#   listen 443 ssl http2;
+#   listen 443 ssl;
+#   http2 on;
 #   server_name coreconnect.io.kr;
 #
 #   # SSL 인증서 설정 (Let's Encrypt)


### PR DESCRIPTION
원인: 이미지가 이전 설정으로 빌드되어 nginx가 인증서 파일을 찾고 있습니다. frontend 이미지를 재빌드하세요.
해결 방법
1단계: frontend 이미지 재빌드
# frontend 이미지 재빌드docker compose build frontend
2단계: 컨테이너 재시작
# frontend 컨테이너 재시작docker compose up -d frontend# 또는 모든 컨테이너 재시작docker compose downdocker compose up -d
3단계: 로그 확인
# nginx 로그 확인docker logs nginx-container# 컨테이너 상태 확인docker ps | grep nginx-container
한 번에 실행
# 이미지 재빌드 및 재시작docker compose build frontend && docker compose up -d frontend
추가 수정 사항
http2 directive 경고를 해결하기 위해 nginx.conf를 수정했습니다:
변경 전: listen 443 ssl http2; (deprecated)
변경 후: listen 443 ssl; + http2 on; (새로운 방식)