### PR TITLE
nginx conf 수정

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,8 +5,9 @@ server {
 
   # Let's Encrypt ACME challenge 경로 (인증서 발급 및 갱신용)
   location /.well-known/acme-challenge/ {
-    root /usr/share/nginx/html;
+    alias /usr/share/nginx/html/.well-known/acme-challenge/;
     try_files $uri =404;
+    access_log off;
   }
 
   # 인증서가 있으면 HTTPS로 리다이렉트, 없으면 HTTP로 계속 서비스


### PR DESCRIPTION
변경 사항
nginx.conf에서 root 대신 alias를 사용하도록 수정했습니다:
변경 전: root /usr/share/nginx/html;
변경 후: alias /usr/share/nginx/html/.well-known/acme-challenge/;