### PR TITLE
RDS에서 Docker MySQL 컨테이너로 마이그레이션

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -91,6 +91,7 @@ jobs:
           echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> .env
           echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> .env
           echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> .env
+          echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> .env
           echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> .env
           echo "MYSQL_PORT=${{ secrets.MYSQL_PORT }}" >> .env
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
@@ -635,6 +635,31 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 	    		}
 	    	}
 	    	
+	    	// ===== 질문 1: 왜 두 번 saveAndFlush()를 하나요? =====
+
+	    	// 답변:
+	    	// - 첫 번째: 정상적인 안읽음 상태 처리 (readYn=false, readAt=null)
+	    	// - 두 번째: 비정상적인 불일치 상태 수정 (readYn=false, readAt≠null)
+	    	// → 서로 다른 조건에서 실행됨! (동시에 실행 안 됨)
+
+	    	// ===== 질문 2: 불일치 row 강제 동기화란? =====
+
+	    	// 답변:
+	    	// - readAt(읽은 시간)은 있는데 readYn(읽음 여부)가 false인 비정상 상태
+	    	// - 논리적 모순: "안 읽었는데 읽은 시간이 있다?"
+	    	// - 원인: 동시성 문제, 트랜잭션 롤백, DB 수정 실수, 버그 등
+	    	// - 해결: 자동으로 readYn을 true로 수정하여 정합성 복구
+
+	    	// ===== 왜 이렇게 하나요? =====
+
+	    	// 1️⃣ 방어적 프로그래밍
+//	    	    - 예상치 못한 상황에도 시스템이 자동으로 복구
+
+	    	// 2️⃣ 데이터 정합성 보장
+//	    	    - 불일치 상태를 방치하지 않고 즉시 수정
+
+	    	// 3️⃣ 시스템 신뢰성 향상
+//	    	    - 버그나 동시성 문제로 인한 영향 최소화
 	    	// 불일치 row 강제 동기화 (optional)
 	        if (status.getReadAt() != null && Boolean.FALSE.equals(status.getReadYn())) {
 	            status.markRead();

--- a/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
@@ -349,3 +349,7 @@ public class JMeterResultAnalyzer {
 
 
 
+
+
+
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
@@ -357,3 +357,7 @@ public class MetricsAnalyzer {
 
 
 
+
+
+
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
@@ -121,3 +121,7 @@ class PerformanceMetricsTest {
 
 
 
+
+
+
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceReportGenerator.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceReportGenerator.java
@@ -208,3 +208,7 @@ public class PerformanceReportGenerator {
 
 
 
+
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,34 @@
 services:
-  # 1. backend 서비스 생성
+  # 1. MySQL 서비스 추가 ⭐
+  mysql:
+    container_name: mysql-container
+    image: mysql:8.0
+    networks:
+      - my-network
+    expose:
+      - "3306"
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      # ⭐ 데이터 영구 저장 (컨테이너 삭제해도 데이터 보존)
+      - mysql-data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # 2. backend 서비스 생성
   backend:
     # 1) 도커 컨테이너 이름
     container_name: boot-container
@@ -14,7 +43,11 @@ services:
       - "8080"
     # 5) 재시작 정책: 수동으로 중지하지 않는 한 항상 재시작
     restart: unless-stopped
-    # 6) Healthcheck: Spring Boot Actuator를 사용한 헬스 체크
+    # 6) MySQL 서비스가 준비될 때까지 대기 ⭐
+    depends_on:
+      mysql:
+        condition: service_healthy
+    # 7) Healthcheck: Spring Boot Actuator를 사용한 헬스 체크
     # Rolling Update 시 새 컨테이너가 완전히 준비될 때까지 대기
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health || exit 1"]
@@ -22,7 +55,7 @@ services:
       timeout: 5s
       retries: 30
       start_period: 90s
-    # 7) docker-compose를 사용하면 Dockerfile를 통하지 않아도 환경 변수를 직접 컨테이너(boot-container)로 전달 가능
+    # 8) docker-compose를 사용하면 Dockerfile를 통하지 않아도 환경 변수를 직접 컨테이너(boot-container)로 전달 가능
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
@@ -75,3 +108,8 @@ services:
 networks:
   my-network:
     external: true
+
+# MySQL 데이터 영구 저장을 위한 볼륨
+volumes:
+  mysql-data:
+    driver: local


### PR DESCRIPTION
services:
  mysql:       # ⭐ MySQL 컨테이너 추가!
  backend:     # Spring Boot
  frontend:    # Nginx

volumes:
  mysql-data:  # ⭐ 데이터 영구 저장
  
  mysql:
  container_name: mysql-container
  image: mysql:8.0
  networks:
    - my-network
  expose:
    - "3306"
  restart: unless-stopped
  environment:
    MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}  # ⭐ 새 환경변수
    MYSQL_DATABASE: ${MYSQL_DATABASE}
    MYSQL_USER: ${MYSQL_USER}
    MYSQL_PASSWORD: ${MYSQL_PASSWORD}
    TZ: Asia/Seoul
  volumes:
    - mysql-data:/var/lib/mysql  # ⭐ 데이터 영구 저장
  command:
    - --character-set-server=utf8mb4
    - --collation-server=utf8mb4_unicode_ci
    - --default-time-zone=+09:00
  healthcheck:
    test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
    interval: 10s
    timeout: 5s
    retries: 5
    start_period: 30s
    
    
    # STEP 1: MySQL 컨테이너 생성
Creating mysql-container ... 
[+] MySQL 8.0 이미지 다운로드 (최초 1회, 150MB)
[+] 컨테이너 시작
[+] Health Check 시작 (10초마다 ping)
[+] 30초 후 Health Check 통과 ✅

# STEP 2: Backend 컨테이너 생성 (MySQL 준비 완료 후)
Creating boot-container ... 
[+] Spring Boot 시작
[+] MySQL 연결: jdbc:mysql://mysql-container:3306/coreconnect
[+] HikariPool 연결 성공 ✅
[+] 90초 후 Health Check 통과 ✅

# STEP 3: Frontend 컨테이너 생성
Creating nginx-container ... 
[+] Nginx 시작
[+] 포트 80, 443 오픈 ✅

# 완료!