### PR TITLE
메시지 전송시 unreadCount 업데이트

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/chat/handler/ChatWebSocketHandler.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/handler/ChatWebSocketHandler.java
@@ -346,11 +346,36 @@ public class ChatWebSocketHandler extends TextWebSocketHandler{
 	        String topic = "/topic/chat.room." + roomId;
 	        messagingTemplate.convertAndSend(topic, unreadCountUpdate);
 	        
-	        log.info("[handleTextMessage] ⭐ UNREAD_COUNT_UPDATE 브로드캐스트 완료 - chatId: {}, unreadCount: {}, topic: {}", 
-	                dto.getId(), latestUnreadCount, topic);
-	    }
+        log.info("[handleTextMessage] ⭐ UNREAD_COUNT_UPDATE 브로드캐스트 완료 - chatId: {}, unreadCount: {}, topic: {}", 
+                dto.getId(), latestUnreadCount, topic);
+        
+        // ⭐ 메시지 전송 후 각 참여자별로 채팅방 전체 unreadCount 계산 및 전송
+        // 발신자를 포함한 모든 참여자에게 최신 unreadCount 전송
+        for (Integer participantId : participantIds) {
+            // ⭐ 각 참여자별로 채팅방의 안 읽은 메시지 수 계산
+            int totalUnreadCount = chatMessageReadStatusRepository
+                .countByUserIdAndChatRoomIdAndReadYnFalse(participantId, roomId);
+            
+            // ⭐ 참여자 정보 조회
+            Optional<User> participantOpt = userRepository.findById(participantId);
+            String participantEmail = participantOpt.map(User::getEmail).orElse(null);
+            
+            // ⭐ ROOM_UNREAD_COUNT_UPDATE 메시지 전송 (채팅방 전체 unreadCount)
+            Map<String, Object> roomUpdateMessage = new HashMap<>();
+            roomUpdateMessage.put("type", "ROOM_UNREAD_COUNT_UPDATE");
+            roomUpdateMessage.put("roomId", roomId);
+            roomUpdateMessage.put("unreadCount", totalUnreadCount); // ⭐ 채팅방 전체 unreadCount
+            roomUpdateMessage.put("participantId", participantId); // ⭐ 대상 참여자 ID
+            roomUpdateMessage.put("participantEmail", participantEmail); // ⭐ 대상 참여자 이메일
+            
+            // ⭐ 모든 참여자에게 전송 (각 참여자가 자신의 unreadCount만 적용)
+            messagingTemplate.convertAndSend(topic, roomUpdateMessage);
+            log.info("[handleTextMessage] ⭐ ROOM_UNREAD_COUNT_UPDATE 전송 - roomId: {}, participantId: {}, participantEmail: {}, totalUnreadCount: {}", 
+                    roomId, participantId, participantEmail, totalUnreadCount);
+        }
+    }
 
-	    String payload = objectMapper.writeValueAsString(dto);
+    String payload = objectMapper.writeValueAsString(dto);
 
 	    // ⭐ 전체 참가자에게 메시지 push (여러 브라우저/탭 지원)
 	    for (Integer pid : participantIds) {


### PR DESCRIPTION
문제 원인
채팅방 접속 시에만 ROOM_UNREAD_COUNT_UPDATE를 전송
메시지 전송 시에는 전송하지 않아서, 발신자의 채팅방 목록 unreadCount가 업데이트되지 않음
해결 방법
handleTextMessage 메서드에 ROOM_UNREAD_COUNT_UPDATE 전송 로직 추가:
메시지 저장 후 각 참여자별로 채팅방 전체 unreadCount 계산
모든 참여자에게 ROOM_UNREAD_COUNT_UPDATE 전송
각 사용자는 자신의 participantEmail과 일치하는 경우에만 roomList 업데이트
동작 흐름
A 사용자가 메시지 전송
백엔드: 메시지 저장 및 읽음 상태 초기화
백엔드: 각 참여자별 unreadCount 계산
A (발신자): unreadCount = 0 (자동 읽음 처리)
B (접속 중): unreadCount = 0 (접속 중이므로 읽음 처리)
백엔드: ROOM_UNREAD_COUNT_UPDATE 전송
프론트엔드: 각 사용자가 자신의 unreadCount 적용
결과: 양쪽 모두 채팅방 목록의 읽지 않음 표시가 0으로 업데이트 ✅