### PR TITLE
update HTTPS ACME challenge path to use alias

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -190,7 +190,8 @@ server {
 #
 #   # Let's Encrypt ACME challenge 경로 (인증서 갱신용)
 #   location /.well-known/acme-challenge/ {
-#     root /usr/share/nginx/html;
+#     alias /usr/share/nginx/html/.well-known/acme-challenge/;
 #     try_files $uri =404;
+#     access_log off;
 #   }
 # }


### PR DESCRIPTION
AS-IS (기존 문제점)
1️⃣ 채팅 unreadCount 문제
문제: 동일한 채팅방에 두 사용자가 접속 중일 때, 메시지 전송 후 발신자의 읽지 않음 표시(unreadCount)가 자동으로 사라지지 않음
재현:
A, B 사용자가 동일한 채팅방에 접속
A 사용자가 메시지 전송
B 사용자는 이미 접속 중이므로 자동 읽음 처리되어야 함
문제: A 사용자의 채팅방 목록에 읽지 않음 표시(1)가 그대로 유지됨
새로고침을 해야만 unreadCount가 업데이트됨
원인:
백엔드: 채팅방 접속 시에만 ROOM_UNREAD_COUNT_UPDATE 전송, 메시지 전송 시에는 미전송
프론트엔드: ROOM_UNREAD_COUNT_UPDATE 처리 후 sortRoomList 미호출로 화면 리렌더링 안 됨
2️⃣ HTTPS 미지원
HTTP만 지원, HTTPS 미설정
보안 통신 불가능
인증서 챌린지 파일이 Git에 포함되어 배포 시 권한 오류 발생
TO-BE (개선 사항)
1️⃣ 채팅 unreadCount 실시간 업데이트
백엔드 (ChatWebSocketHandler.java)
// ✅ 메시지 전송 시에도 각 참여자별 unreadCount 계산 및 전송handleTextMessage() {  // ... 메시지 저장 후    // 각 참여자별로 채팅방 전체 unreadCount 계산  for (Integer participantId : participantIds) {    int totalUnreadCount = chatMessageReadStatusRepository        .countByUserIdAndChatRoomIdAndReadYnFalse(participantId, roomId);        // ROOM_UNREAD_COUNT_UPDATE 메시지 전송 (participantEmail 포함)    Map<String, Object> roomUpdateMessage = new HashMap<>();    roomUpdateMessage.put("type", "ROOM_UNREAD_COUNT_UPDATE");    roomUpdateMessage.put("roomId", roomId);    roomUpdateMessage.put("unreadCount", totalUnreadCount);    roomUpdateMessage.put("participantEmail", participantEmail);        messagingTemplate.convertAndSend(topic, roomUpdateMessage);  }}
프론트엔드 (ChatLayout.jsx)
// ✅ ROOM_UNREAD_COUNT_UPDATE 처리 시 정렬 추가if (msg && msg.type === "ROOM_UNREAD_COUNT_UPDATE") {  setRoomList((prevRoomList) => {    const updated = prevRoomList.map((room) => {      if (Number(room.roomId) === roomIdNum) {        return {          ...room,          unreadCount: Number(unreadCount) || 0        };      }      return room;    });        // ⭐ 정렬하여 반환 (화면 리렌더링 트리거)    return sortRoomList(updated);  });}
2️⃣ HTTPS 설정 추가
nginx.conf
HTTPS(443) 서버 블록 주석 해제
SSL 인증서 경로 설정
ACME challenge 경로 수정 (root → alias)
docker-compose.yml
volumes:  - /etc/letsencrypt:/etc/letsencrypt:ro  # ✅ 인증서 볼륨 마운트  - ./frontend/letsencrypt-challenge:/usr/share/nginx/html/.well-known/acme-challenge
.gitignore
# ✅ Let's Encrypt 챌린지 파일 제외 (서버에서 생성)frontend/letsencrypt-challenge/
