### PR TITLE
Fix: Allow /actuator/health for Docker health check and add /ws/chat-raw for load testing

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/goodee/coreconnect/security/config/SecurityConfig.java
@@ -84,11 +84,14 @@ public class SecurityConfig {
                     "/swagger-resources/**",              // Swagger 리소스
                     "/webjars/**",                        // WebJars 리소스
                     "/ws/chat/**",                        // WebSocket 채팅 (SockJS info 엔드포인트 접근용, 실제 연결은 WebSocketAuthInterceptor에서 검증)
+                    "/ws/chat-raw/**",                    // WebSocket 부하 테스트용 (인증 없음)
                     "/ws/notification/**",                // WebSocket 알림
                     "/api/v1/auth/**",                    // 인증 관련 API
                     "/api/v1/password-reset/requests",    // 비밀번호 초기화 요청
                     "/api/health",                        // AWS ELB 헬스체크 (기본)
-                    "/api/health/**"                      // AWS ELB 헬스체크 (상세, liveness, readiness)
+                    "/api/health/**",                     // AWS ELB 헬스체크 (상세, liveness, readiness)
+                    "/actuator/health",                   // Docker Health Check
+                    "/actuator/health/**"                 // Docker Health Check (상세)
                 ).permitAll()
                 // 나머지 경로는 로그인 필요
                 .anyRequest().authenticated()


### PR DESCRIPTION
변경 내용
SecurityConfig에 다음을 추가했습니다:
/actuator/health - Docker Health Check 허용
/actuator/health/** - 상세 Health Check 허용
/ws/chat-raw/** - 부하 테스트용 WebSocket 엔드포인트 허용