### PR TITLE
feat: Add load testing endpoints and fix Docker health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,15 +47,14 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-    # 7) Healthcheck: Spring Boot Actuator를 사용한 헬스 체크
+    # 7) Healthcheck: 커스텀 /api/health 엔드포인트 사용
     # Rolling Update 시 새 컨테이너가 완전히 준비될 때까지 대기
-    # ⚠️ 임시로 주석 처리 (curl 없는 경우)
-    # healthcheck:
-    #   test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health || exit 1"]
-    #   interval: 10s
-    #   timeout: 5s
-    #   retries: 30
-    #   start_period: 90s
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 90s
     # 8) docker-compose를 사용하면 Dockerfile를 통하지 않아도 환경 변수를 직접 컨테이너(boot-container)로 전달 가능
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8


### PR DESCRIPTION
## 🎯 목적
Docker 컨테이너 health check 실패 문제 해결 및 WebSocket 부하 테스트 환경 구축

## 📝 변경 사항

### 1. WebSocket 부하 테스트 엔드포인트 추가
- **파일**: `backend/src/main/java/com/goodee/coreconnect/config/WebSocketConfig.java`
- `/ws/chat-raw` 엔드포인트 추가
- SockJS 없는 순수 WebSocket 지원
- 인증 불필요 (부하 테스트 전용)

### 2. Spring Security 설정 업데이트
- **파일**: `backend/src/main/java/com/goodee/coreconnect/security/config/SecurityConfig.java`
- `/actuator/health` 경로 인증 제외 처리
- `/ws/chat-raw/**` 경로 인증 제외 처리
- Docker health check 401 에러 해결

### 3. Docker Health Check 수정
- **파일**: `docker-compose.yml`
- Health check 엔드포인트: `/actuator/health` → `/api/health` 변경
- 주석 처리된 health check 활성화
- `start_period: 90s` 유지 (애플리케이션 초기화 시간 고려)

## 🐛 해결된 문제
- Docker 컨테이너가 `unhealthy` 상태로 표시되던 문제 해결
- Health check가 401 Unauthorized 에러로 실패하던 문제 해결
- k6 부하 테스트 도구가 WebSocket에 연결할 수 없던 문제 해결

## ✅ 테스트
- [x] 백엔드 컨테이너가 `healthy` 상태로 전환 확인
- [x] `/api/health` 엔드포인트 정상 응답 확인
- [x] `/ws/chat-raw` WebSocket 연결 테스트 완료
- [x] k6 부하 테스트 도구 연동 확인

## 📸 스크린샷 / 로그
# Health Check 성공
$ curl http://localhost:8080/api/health
{"service":"CoreConnect Backend","status":"UP"}

# Docker 컨테이너 상태
$ docker-compose ps
NAME              STATUS
boot-container    Up (healthy)## 🔗 관련 이슈
- Fixes #XXX (이슈 번호가 있다면)

## 📌 추가 참고사항
- 부하 테스트 서버: `15.165.43.131`
- 백엔드 서버: `54.116.26.182:8080`
- 부하 테스트는 `/ws/chat-raw` 엔드포인트 사용 권장