### PR TITLE
feat: WebSocket STOMP 채팅 부하 테스트 및 JWT 인증 구현

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/goodee/coreconnect/config/WebSocketConfig.java
@@ -87,9 +87,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 부하 테스트용 순수 WebSocket 엔드포인트 (SockJS 없음)
         registry.addEndpoint("/ws/chat-raw")
                 .setAllowedOrigins("*") // 부하 테스트용이므로 모든 origin 허용
-                // 인터셉터 없음 - 부하 테스트에서는 인증 생략
+                .addInterceptors(webSocketAuthInterceptor) // ✅ JWT 인증 추가
                 ; // SockJS 없음
-        log.info("🔥 [WebSocketConfig] /ws/chat-raw 엔드포인트 등록 완료 (부하 테스트용)");
+        log.info("🔥 [WebSocketConfig] /ws/chat-raw 엔드포인트 등록 완료 (부하 테스트용, JWT 인증 포함)");
         
         // 알림 WebSocket은 NotificationWebSocketConfig에서 별도로 등록됨 (일반 WebSocket 핸들러)
         log.info("🔥 [WebSocketConfig] /ws/notification은 NotificationWebSocketConfig에서 등록됨");


### PR DESCRIPTION
## 📋 요약

WebSocket 기반 실시간 채팅 시스템의 성능 검증을 위한 부하 테스트 인프라를 구축하고, JWT 인증 오버헤드를 측정할 수 있도록 개선했습니다.

## 🎯 목적

- 실시간 채팅 시스템의 성능 한계 파악
- JWT 인증 오버헤드 측정 및 최적화 방안 도출
- 동시 접속자 증가 시 안정성 검증
- 실제 프로덕션 환경과 유사한 부하 테스트 환경 구축

## ✨ 주요 변경사항

### 1. 백엔드 코드 변경

#### `WebSocketConfig.java`
- `/ws/chat-raw` 엔드포인트에 JWT 인증 인터셉터 추가
- 부하 테스트 환경에서도 실제 인증 플로우 적용

**변경 전:**
registry.addEndpoint("/ws/chat-raw")
    .setAllowedOrigins("*")
    // 인터셉터 없음
    ;**변경 후:**
registry.addEndpoint("/ws/chat-raw")
    .setAllowedOrigins("*")
    .addInterceptors(webSocketAuthInterceptor) // ✅ JWT 인증 추가
    ;### 2. 부하 테스트 인프라

#### `k6-jwt-auth-test.js`
- k6 Cloud 기반 실시간 모니터링
- STOMP 프로토콜 WebSocket 시나리오
- JWT 인증 플로우 포함 (로그인 → 연결 → 메시지 전송)

**주요 기능:**
- 테스트 계정 5개 순환 사용
- 5개 채팅방에 사용자 분산
- 메시지 레이턴시 측정
- 인증 오버헤드 측정

**테스트 시나리오:**
stages: [
  { duration: '30s', target: 20 },  // Ramp-up
  { duration: '1m', target: 50 },   // Load
  { duration: '30s', target: 0 },   // Ramp-down
]#### `테스트_계정_생성.sql`
- 테스트용 계정 5개 생성 스크립트
- 테스트용 채팅방 5개 생성
- 모든 사용자를 모든 채팅방에 자동 참여

### 3. 문서화

#### `채팅_부하테스트_결과_분석.md`
- AS-IS 성능 지표 상세 분석
- 문제점 원인 규명 (STOMP 엔드포인트 불일치)
- 3단계 개선 방안 (긴급/성능/확장성)
- TO-BE 목표 수치 및 아키텍처

#### `JWT_인증_부하테스트_가이드.md`
- 사전 준비부터 결과 분석까지 전 과정
- 백엔드 수정 가이드
- 테스트 계정 생성 방법
- 문제 해결 가이드
- 성능 개선 로드맵

## 📊 테스트 결과

### AS-IS (현재 상태)

| 지표 | 측정값 | 평가 |
|------|--------|------|
| 총 세션 수 | 149 | ✅ 정상 |
| 메시지 전송 | 1,192개 | ✅ 정상 |
| 메시지 수신 | 149개 | 🚨 심각 |
| **수신률** | **12.5%** | 🚨 **87.5% 손실** |
| P95 연결 시간 | 348ms | ✅ 양호 |

### 문제점 발견

**🚨 치명적 문제: 메시지 수신률 12.5%**

**원인:**
- STOMP 엔드포인트 불일치
  - 테스트: `/app/chat` → 백엔드: `/app/chat.sendMessage`
  - 테스트: `/topic/chat/{roomId}` → 백엔드: `/topic/chat.room.{roomId}`
- 메시지 수신 전 연결 종료 (3초 타임아웃)
- 방 분산도 과다 (10개 방에 50명 분산)

### TO-BE (개선 목표)

| 지표 | AS-IS | TO-BE 목표 | 개선율 |
|------|-------|------------|--------|
| 메시지 수신률 | 12.5% | **95% 이상** | 7.6배 |
| P95 응답 시간 | 348ms | **450ms** | +102ms (JWT) |
| 동시 접속자 | 50명 | **1,000명** | 20배 |
| 메시지 처리량 | 10 msg/s | **200 msg/s** | 20배 |

## 🔐 JWT 인증 오버헤드

### 측정 목표

- 로그인 시간 (auth_time)
- WebSocket 핸드셰이크 시간
- 전체 메시지 레이턴시 증가분

### 예상 오버헤드
