### PR TITLE
fix: MySQL 포트를 외부에서 접근 가능하도록 포트 매핑 추가 (3306:3306)

### DIFF
--- a/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
@@ -376,3 +376,4 @@ public class JMeterResultAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
@@ -384,3 +384,4 @@ public class MetricsAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
@@ -148,3 +148,4 @@ class PerformanceMetricsTest {
 
 
 
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: mysql:8.0
     networks:
       - my-network
+    ports:
+      - "3306:3306"
     expose:
       - "3306"
     restart: unless-stopped


### PR DESCRIPTION

## 🔍 원인 분석
기존 `docker-compose.yml` 설정에서 MySQL 컨테이너가 `expose`만 사용하고 있어, Docker 네트워크 내부에서만 접근 가능했습니다.
- `expose`: Docker 네트워크 내부 컨테이너 간 통신만 가능
- `ports`: 호스트 시스템에 포트를 매핑하여 외부에서도 접근 가능

## ✅ 해결 방법
MySQL 서비스에 `ports` 매핑을 추가하여 호스트의 3306 포트를 컨테이너의 3306 포트와 연결했습니다.

### 변경 내용
mysql:
  container_name: mysql-container
  image: mysql:8.0
  networks:
    - my-network
  ports:                    # ⭐ 추가
    - "3306:3306"          # ⭐ 추가
  expose:
    - "3306"## 📊 영향도
- ✅ MySQL Workbench, DBeaver 등 외부 DB 클라이언트에서 접속 가능
- ✅ 로컬 개발 환경에서 원격 DB 직접 접근 가능
- ✅ 기존 컨테이너 간 통신은 영향 없음 (네트워크 내부 통신 유지)
- ⚠️ 보안: 3306 포트가 외부에 노출되므로, 필요시 AWS Security Group에서 특정 IP만 허용하도록 설정 권장

## 🧪 테스트 방법
1. 서버에서 `docker-compose down && docker-compose up -d` 실행
2. `docker ps | grep mysql`로 포트 매핑 확인 (0.0.0.0:3306->3306/tcp)
3. MySQL Workbench에서 `54.116.26.182:3306` 접속 테스트

## 📝 참고사항
- 운영 환경에서는 보안을 위해 AWS Security Group 설정 검토 필요
- 필요시 특정 IP 대역에서만 3306 포트 접근 허용하도록 제한 권장