### PR TITLE
feat: optimize chat latest messages (paging, async read) and tuning

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatRoomLatestMessageDTO.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/dto/response/ChatRoomLatestMessageDTO.java
@@ -1,0 +1,26 @@
+package com.goodee.coreconnect.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 채팅방 목록 조회 시 최신 메시지만 담는 슬림 DTO
+ * 필요한 필드만 노출하여 페이로드를 최소화한다.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomLatestMessageDTO {
+    private Integer roomId;
+    private String roomName;
+    private Integer lastMessageId;
+    private String lastMessageContent;
+    private String lastSenderName;
+    private LocalDateTime lastMessageTime;
+}
+

--- a/backend/src/main/java/com/goodee/coreconnect/chat/event/MessageReadEvent.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/event/MessageReadEvent.java
@@ -1,0 +1,26 @@
+package com.goodee.coreconnect.chat.event;
+
+public class MessageReadEvent {
+    private final Long userId;
+    private final Long roomId;
+    private final Long messageId;
+
+    public MessageReadEvent(Long userId, Long roomId, Long messageId) {
+        this.userId = userId;
+        this.roomId = roomId;
+        this.messageId = messageId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getRoomId() {
+        return roomId;
+    }
+
+    public Long getMessageId() {
+        return messageId;
+    }
+}
+

--- a/backend/src/main/java/com/goodee/coreconnect/chat/event/MessageReadEventListener.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/event/MessageReadEventListener.java
@@ -1,0 +1,40 @@
+package com.goodee.coreconnect.chat.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.goodee.coreconnect.chat.repository.ChatMessageReadStatusRepository;
+import com.goodee.coreconnect.notification.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 메시지 읽음 처리/알림 카운트 감소 등 부가 작업을 비동기(@Async)로 처리하여
+ * 요청 응답 지연(P95) 스파이크를 줄인다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MessageReadEventListener {
+
+    private final ChatMessageReadStatusRepository readStatusRepo;
+    private final NotificationService notificationService; // 알림/미읽음 카운트 감소용
+
+    @Async("asyncTaskExecutor")
+    @EventListener
+    public void handle(MessageReadEvent event) {
+        try {
+            // 읽음 상태 업데이트
+            readStatusRepo.updateReadStatus(event.getUserId(), event.getMessageId());
+
+            // 알림/미읽음 카운트 감소 (빈이 없으면 예외 방지)
+            if (notificationService != null) {
+                notificationService.decreaseUnreadCount(event.getUserId(), event.getRoomId());
+            }
+        } catch (Exception e) {
+            log.warn("MessageReadEvent handling failed: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/repository/ChatRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,10 +19,12 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     List<Chat> findByChatRoomId(Integer id);
 
     // 2. 여러 채팅방의 모든 메시지 (sender도 함께 로드)
-    @Query("SELECT c FROM Chat c LEFT JOIN FETCH c.sender WHERE c.chatRoom.id IN :roomIds")
+    @EntityGraph(attributePaths = {"sender", "chatRoom"})
+    @Query("SELECT c FROM Chat c WHERE c.chatRoom.id IN :roomIds")
     List<Chat> findByChatRoomIds(@Param("roomIds") List<Integer> roomIds);
 
     // 3. 채팅방의 모든 메시지(오름차순)
+    @EntityGraph(attributePaths = {"sender", "chatRoom"})
     List<Chat> findByChatRoomIdOrderBySendAtAsc(Integer roomId);
 
     // 채팅방의 안읽은 메시지(모든 참여자 기준)
@@ -38,7 +41,12 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     List<Chat> findByChatRoom_IdAndReadYnIsFalseWithSender(@Param("roomId") Integer chatRoomId);
     
     // 5. 내가 참여중인 채팅방들의 마지막 메시지만 조회
-    @Query("SELECT c FROM Chat c WHERE c.chatRoom.id IN :roomIds AND c.sendAt = (SELECT MAX(c2.sendAt) FROM Chat c2 WHERE c2.chatRoom.id = c.chatRoom.id)")
+    // ⭐ N+1 문제 해결: sender와 chatRoom을 함께 Fetch Join
+    @Query("SELECT c FROM Chat c " +
+           "LEFT JOIN FETCH c.sender " +
+           "LEFT JOIN FETCH c.chatRoom " +
+           "WHERE c.chatRoom.id IN :roomIds " +
+           "AND c.sendAt = (SELECT MAX(c2.sendAt) FROM Chat c2 WHERE c2.chatRoom.id = c.chatRoom.id)")
     List<Chat> findLatestMessageByChatRoomIds(@Param("roomIds") List<Integer> roomIds);
 
     // 6. 채팅방 내에서 특정 메시지의 미읽은 인원 조회 (ChatMessageReadStatus 활용)
@@ -47,8 +55,27 @@ public interface ChatRepository extends JpaRepository<Chat, Integer> {
     List<Object[]> countUnreadByRoomId(@Param("roomId") Integer roomId);
     
     // 7. 각 채팅방의 가장 마지막(최신) 메시지
-    @Query("SELECT c FROM Chat c WHERE c.chatRoom.id IN :roomIds AND c.sendAt = (SELECT MAX(c2.sendAt) FROM Chat c2 WHERE c2.chatRoom.id = c.chatRoom.id)")
+    // ⭐ N+1 문제 해결: sender와 chatRoom을 함께 Fetch Join
+    @Query("SELECT c FROM Chat c " +
+           "LEFT JOIN FETCH c.sender " +
+           "LEFT JOIN FETCH c.chatRoom " +
+           "WHERE c.chatRoom.id IN :roomIds " +
+           "AND c.sendAt = (SELECT MAX(c2.sendAt) FROM Chat c2 WHERE c2.chatRoom.id = c.chatRoom.id)")
     List<Chat> findLatestMessagesByRoomIds(@Param("roomIds") List<Integer> roomIds);
+
+    /**
+     * 채팅방 목록 조회 시 최신 메시지만 페이징으로 가져오기 (Top-N)
+     * - 페이로드/쿼리 부하를 줄이기 위해 Pageable(limit/offset) 적용
+     * - 기존 전체 조회 대비 DB/네트워크 비용 감소
+     *
+     * 주의: fetch join + pagination 조합은 JPA 구현체에 따라 경고가 날 수 있으므로,
+     *      부하가 크거나 정밀한 튜닝이 필요하면 Projection + 별도 쿼리로 분리 검토.
+     */
+    @EntityGraph(attributePaths = {"sender", "chatRoom"})
+    @Query("SELECT c FROM Chat c " +
+           "WHERE c.chatRoom.id IN :roomIds " +
+           "AND c.sendAt = (SELECT MAX(c2.sendAt) FROM Chat c2 WHERE c2.chatRoom.id = c.chatRoom.id)")
+    Page<Chat> findLatestMessagesByRoomIdsPaged(@Param("roomIds") List<Integer> roomIds, Pageable pageable);
     
     
     // 8. 채팅방에서 메시지를 불러올때 파일이 있는 경우 파일들도 함께 조회

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.goodee.coreconnect.approval.entity.Document;
 import com.goodee.coreconnect.chat.dto.response.ChatResponseDTO;
+import com.goodee.coreconnect.chat.dto.response.ChatRoomLatestMessageDTO;
 import com.goodee.coreconnect.chat.dto.response.ChatRoomLatestMessageResponseDTO;
 import com.goodee.coreconnect.chat.dto.response.ChatRoomListDTO;
 import com.goodee.coreconnect.chat.dto.response.ChatRoomSummaryResponseDTO;
@@ -93,5 +94,10 @@ public interface ChatRoomService {
 
 	// 채팅방 나가기
 	void leaveChatRoom(Integer roomId, String userEmail);
+
+	/**
+	 * Top-N 페이징: 최신 메시지 기준으로 채팅방을 페이징 조회 (슬림 DTO)
+	 */
+    org.springframework.data.domain.Page<ChatRoomLatestMessageDto> getLatestMessagesPaged(Integer userId, org.springframework.data.domain.Pageable pageable);
 
 }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
@@ -24,6 +24,7 @@ import com.goodee.coreconnect.account.repository.AccountLogRepository;
 import com.goodee.coreconnect.approval.entity.Document;
 import com.goodee.coreconnect.approval.repository.DocumentRepository;
 import com.goodee.coreconnect.chat.dto.response.ChatResponseDTO;
+import com.goodee.coreconnect.chat.dto.response.ChatRoomLatestMessageDTO;
 import com.goodee.coreconnect.chat.dto.response.ChatRoomLatestMessageResponseDTO;
 import com.goodee.coreconnect.chat.dto.response.ChatRoomListDTO;
 import com.goodee.coreconnect.chat.dto.response.ChatRoomSummaryResponseDTO;
@@ -300,6 +301,42 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 	public List<ChatRoomUser> getChatRoomUsers(Integer roomId) {
 		// ⭐ User와 Department를 함께 조회하여 Lazy Loading 문제 해결
 		return chatRoomUserRepository.findByChatRoomIdWithUser(roomId);
+	}
+
+	/**
+	 * Top-N 페이징: 최신 메시지 기준 채팅방 목록을 슬림 DTO로 반환
+	 * - roomId, roomName, lastMessage, senderName, sendAt 등만 노출
+	 * - 페이로드와 쿼리 부하를 줄이기 위한 목적
+	 */
+	@Transactional(readOnly = true)
+	@Override
+	public org.springframework.data.domain.Page<ChatRoomLatestMessageDto> getLatestMessagesPaged(Integer userId, org.springframework.data.domain.Pageable pageable) {
+	    // 사용자가 참여 중인 채팅방 id 목록 조회
+	    List<ChatRoomUser> chatRoomUsers = chatRoomUserRepository.findByUserId(userId);
+	    List<Integer> roomIds = chatRoomUsers.stream()
+	            .map(cru -> cru.getChatRoom().getId())
+	            .distinct()
+	            .collect(Collectors.toList());
+
+	    if (roomIds.isEmpty()) {
+	        return org.springframework.data.domain.Page.empty(pageable);
+	    }
+
+	    // 최신 메시지 페이징 조회 (fetch join → service에서 DTO 변환)
+	    Page<Chat> page = chatRepository.findLatestMessagesByRoomIdsPaged(roomIds, pageable);
+
+	    return page.map(chat -> {
+	        ChatRoom room = chat.getChatRoom();
+	        User sender = chat.getSender();
+	        return ChatRoomLatestMessageDto.builder()
+	                .roomId(room != null ? room.getId() : null)
+	                .roomName(room != null ? room.getRoomName() : null)
+	                .lastMessageId(chat.getId())
+	                .lastMessageContent(chat.getMessageContent())
+	                .lastSenderName(sender != null ? sender.getName() : null)
+	                .lastMessageTime(chat.getSendAt())
+	                .build();
+	    });
 	}
 
 	@Override

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatService.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatService.java
@@ -1,0 +1,25 @@
+package com.goodee.coreconnect.chat.service;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import com.goodee.coreconnect.chat.event.MessageReadEvent;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 메시지 조회 후 응답은 바로 반환하고,
+ * 읽음 처리/알림 카운트 등 부가 작업은 이벤트로 발행해 비동기로 처리한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ApplicationEventPublisher publisher;
+
+    public void markAsRead(Long userId, Long roomId, Long messageId) {
+        // 최소 로직만 수행하고 이벤트 발행
+        publisher.publishEvent(new MessageReadEvent(userId, roomId, messageId));
+    }
+}
+

--- a/backend/src/main/java/com/goodee/coreconnect/config/AsyncConfig.java
+++ b/backend/src/main/java/com/goodee/coreconnect/config/AsyncConfig.java
@@ -1,10 +1,23 @@
 package com.goodee.coreconnect.config;
 
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync   // 비동기 기능 활성화
 public class AsyncConfig {
-
+  @Bean(name = "asyncTaskExecutor")
+  public Executor asyncTaskExecutor() {
+      ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+      exec.setCorePoolSize(4);
+      exec.setMaxPoolSize(8);
+      exec.setQueueCapacity(100);
+      exec.setThreadNamePrefix("async-");
+      exec.initialize();
+      return exec;
+  }
 }

--- a/backend/src/main/java/com/goodee/coreconnect/config/NetworkIdleTimeoutLogger.java
+++ b/backend/src/main/java/com/goodee/coreconnect/config/NetworkIdleTimeoutLogger.java
@@ -1,0 +1,32 @@
+package com.goodee.coreconnect.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 서버/LB Idle Timeout 관련 설정을 점검/로그로 알려주는 유틸 컴포넌트.
+ * - HTTP/1.1 Keep-Alive는 기본 동작
+ * - LB/프록시의 Idle Timeout이 서버 설정(connection-timeout)보다 너무 짧거나 긴지 확인 필요
+ */
+@Slf4j
+@Component
+public class NetworkIdleTimeoutLogger implements CommandLineRunner {
+
+    @Value("${server.connection-timeout:20000}")
+    private String serverConnectionTimeout; // ms 또는 ISO-8601(30s) 형태
+
+    @Value("${app.proxy.idle-timeout-seconds:60}")
+    private int proxyIdleTimeoutSeconds;    // LB/프록시 Idle Timeout(수동 입력)
+
+    @Override
+    public void run(String... args) {
+        log.info("HTTP Keep-Alive 기본 활성화 (HTTP/1.1).");
+        log.info("server.connection-timeout = {}", serverConnectionTimeout);
+        log.info("app.proxy.idle-timeout-seconds = {}s (LB/프록시 설정 값 수동 입력)", proxyIdleTimeoutSeconds);
+        log.info("권장: 서버 connection-timeout <= LB Idle Timeout, 필요 시 LB Idle Timeout을 더 길게 설정하거나 동일하게 맞추세요.");
+    }
+}
+

--- a/backend/src/main/resources/application-local-mysql.properties
+++ b/backend/src/main/resources/application-local-mysql.properties
@@ -1,0 +1,83 @@
+# ========================================
+# 로컬 개발 환경 - MySQL 사용 버전
+# ========================================
+# 사용 방법:
+# IntelliJ IDEA: Active profiles에 "local-mysql" 입력
+# ========================================
+
+spring.config.activate.on-profile=local-mysql
+
+# ========================================
+# MySQL 데이터베이스 설정
+# ========================================
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/coreconnect?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+# ⚠️ 여기에 본인의 MySQL root 비밀번호 입력!
+spring.datasource.password=여기에_비밀번호_입력
+
+# ========================================
+# JPA/Hibernate 설정
+# ========================================
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+# 테이블 자동 생성 (개발용)
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
+
+# ========================================
+# 보안 모드 OFF (로컬 개발용)
+# ========================================
+security.mode=open
+
+# ========================================
+# Redis 비활성화
+# ========================================
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.data.redis.password=
+spring.data.redis.timeout=2000ms
+
+# ========================================
+# 외부 서비스 비활성화
+# ========================================
+cloud.aws.credentials.access-key=
+cloud.aws.credentials.secret-key=
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=
+
+sendgrid.api.key=
+sendgrid.from.email=noreply@localhost
+sendgrid.from.name=CoreConnect Local
+
+spring.mail.host=localhost
+spring.mail.port=25
+
+# ========================================
+# JWT 설정
+# ========================================
+jwt.secret=local-development-secret-key-for-testing
+
+# ========================================
+# CORS & WebSocket
+# ========================================
+app.cors.allowed-origins=http://localhost:5173,http://localhost:3000
+app.websocket.allowed-origins=http://localhost:5173,http://localhost:3000
+app.cookie.secure=false
+app.cookie.same-site=Lax
+
+# ========================================
+# 로깅
+# ========================================
+logging.level.com.goodee.coreconnect=DEBUG
+logging.level.org.hibernate.SQL=DEBUG
+
+# ========================================
+# 파일 업로드
+# ========================================
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=100MB
+
+
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,12 +4,12 @@ spring:
   # ==========================================
   datasource:
     hikari:
-      # Connection Pool 크기 (성능 최적화)
-      maximum-pool-size: 50          # 변경: 10 → 50 (동시 접속자 45명 대응)
-      minimum-idle: 20               # 변경: 5 → 20 (항상 20개 유지)
+      # Connection Pool 크기 (부하 테스트용 튜닝)
+      maximum-pool-size: 40          # 테스트 대상: 40 (DB 커넥션 한도에 맞춰 조정)
+      minimum-idle: 10               # 테스트 대상: 10 (유휴 커넥션 유지 최소값)
       
       # 타임아웃 설정
-      connection-timeout: 20000      # 20초 (Connection 대기 시간)
+      connection-timeout: 15000      # 15초 (대기 시간 상한을 다소 낮춤)
       idle-timeout: 300000           # 5분 (유휴 Connection 유지)
       max-lifetime: 1200000          # 20분 (Connection 최대 수명)
       
@@ -30,9 +30,17 @@ spring:
 # Tomcat Thread Pool 설정
 # ==========================================
 server:
+  # 서버 커넥션 타임아웃 (LB/프록시와 Idle Timeout 맞춰 확인)
+  connection-timeout: 30s
   tomcat:
     threads:
-      max: 200                      # 최대 스레드 수
-      min-spare: 50                 # 최소 유휴 스레드 (변경: 10 → 50)
-    accept-count: 100               # 요청 대기 큐 크기
-    max-connections: 10000          # 최대 동시 연결 수
+      max: 200                      # 최대 스레드 수 (동일 유지)
+      min-spare: 30                 # 최소 유휴 스레드 (부하 테스트용 약간 축소)
+    accept-count: 150               # 요청 대기 큐 크기 (버스트 대응 약간 확대)
+    max-connections: 10000          # 최대 동시 연결 수 (동일 유지)
+
+  # HTTP 응답 압축 (전송 최적화)
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain
+    min-response-size: 1024  # 1KB 이상부터 압축

--- a/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
@@ -377,3 +377,4 @@ public class JMeterResultAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
@@ -385,3 +385,4 @@ public class MetricsAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
@@ -149,3 +149,4 @@ class PerformanceMetricsTest {
 
 
 
+


### PR DESCRIPTION
주요 변경 요약
1) Top-N 페이징 + 슬림 DTO
ChatRoomLatestMessageDTO 추가 (roomId, roomName, lastMessageId, lastMessageContent, lastSenderName, lastMessageTime).
ChatRepository에 EntityGraph 적용(페치 조인) + findLatestMessagesByRoomIdsPaged(Pageable)로 최신 메시지 페이징 조회.
ChatRoomService/Impl에 getLatestMessagesPaged(userId, pageable) 구현: 참여 채팅방 ID 목록 → 최신 메시지 페이징 → 슬림 DTO 변환.
2) 비동기 이벤트 기반 읽음 처리
MessageReadEvent, ChatService.markAsRead(...)(이벤트 발행), MessageReadEventListener(@Async)로 읽음 상태/알림 카운트 감소 처리.
AsyncConfig import 보완, asyncTaskExecutor 사용.
3) 인덱스 정리 및 생성 스크립트
채팅_테이블_컬럼_추가_스크립트.sql에서 중복 인덱스 정리 예시 + 단일 복합 인덱스 생성:
     CREATE INDEX IF NOT EXISTS idx_chat_message_room_sent_at     ON chat_message(chat_room_id, sent_at DESC);
DROP 예시, EXPLAIN 체크 가이드 추가.
4) 네트워크/압축 최적화
application.yml: server.compression 활성화(GZIP, 1KB 이상), server.connection-timeout: 30s 추가.
NetworkIdleTimeoutLogger: LB/프록시 Idle Timeout 비교 안내 로그 추가(app.proxy.idle-timeout-seconds 수동 입력).
5) HikariCP/Tomcat 부하 테스트용 튜닝 (이미 반영)
HikariCP: maxPool=40, minIdle=10, connection-timeout=15s, idle-timeout=300s, max-lifetime=20m.
Tomcat: maxThreads=200, min-spare=30, accept-count=150, max-connections=10000.
테스트/목표
k6 시나리오: 로그인 → 채팅방 목록/마지막 메시지 조회 반복.
Threshold: P95 < 500ms, 에러율 < 1%, (20 VU 기준 RPS 10~15+ 목표).
기존 결과(P95 ~5.9s, RPS ~6.8) → 인덱스/페이징/비동기 적용 후 재측정 필요.
파일 목록 (주요 변경)
ChatRepository.java: EntityGraph + 페이징 메서드 추가.
ChatRoomService.java / ChatRoomServiceImpl.java: Top-N 페이징 DTO 변환 로직.
chat/dto/response/ChatRoomLatestMessageDTO.java: 슬림 DTO 추가.
chat/event/MessageReadEvent*.java, ChatService.java: 비동기 이벤트 기반 읽음 처리.
config/AsyncConfig.java: import 보완.
채팅_테이블_컬럼_추가_스크립트.sql: 인덱스 정리/생성/EXPLAIN 가이드.
application.yml: Hikari/Tomcat 튜닝, GZIP, connection-timeout 추가.
config/NetworkIdleTimeoutLogger.java: Idle Timeout 안내 로그.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds paged latest-message retrieval with a slim DTO, async event-driven read processing, and connection/compression/config tuning including a local-MySQL profile.
> 
> - **Backend – Chat**:
>   - **Latest Messages Paging (Top-N)**: Introduces slim `ChatRoomLatestMessageDTO`; adds `ChatRepository.findLatestMessagesByRoomIdsPaged(...)` with `@EntityGraph` and fetch-join optimizations; implements `ChatRoomService.getLatestMessagesPaged(...)` mapping to the DTO.
>   - **Async Read Handling**: Adds `MessageReadEvent`, `MessageReadEventListener` (`@Async("asyncTaskExecutor")`) to update read status and decrease unread notifications; `ChatService.markAsRead(...)` publishes the event; configures `AsyncConfig` executor bean.
> - **Config**:
>   - **Server/Pool Tuning**: Adjusts HikariCP timeouts/sizes; sets `server.connection-timeout: 30s`; enables HTTP response compression.
>   - **Observability**: Adds `NetworkIdleTimeoutLogger` to log idle-timeout alignment.
>   - **Profiles**: Adds `application-local-mysql.properties` for local MySQL setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 396ad115069c42b803897672a8b0ec240a27da26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->