### PR TITLE
feat: optimize chat latest messages with paging and async read handling

### DIFF
--- a/backend/src/main/java/com/goodee/coreconnect/chat/event/MessageReadEventListener.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/event/MessageReadEventListener.java
@@ -5,7 +5,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import com.goodee.coreconnect.chat.repository.ChatMessageReadStatusRepository;
-import com.goodee.coreconnect.notification.service.NotificationService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 public class MessageReadEventListener {
 
     private final ChatMessageReadStatusRepository readStatusRepo;
-    private final NotificationService notificationService; // 알림/미읽음 카운트 감소용
 
     @Async("asyncTaskExecutor")
     @EventListener
@@ -29,10 +27,7 @@ public class MessageReadEventListener {
             // 읽음 상태 업데이트
             readStatusRepo.updateReadStatus(event.getUserId(), event.getMessageId());
 
-            // 알림/미읽음 카운트 감소 (빈이 없으면 예외 방지)
-            if (notificationService != null) {
-                notificationService.decreaseUnreadCount(event.getUserId(), event.getRoomId());
-            }
+            // TODO: 알림/미읽음 카운트 감소가 필요하면 NotificationService를 주입해 호출하세요.
         } catch (Exception e) {
             log.warn("MessageReadEvent handling failed: {}", e.getMessage(), e);
         }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomService.java
@@ -98,6 +98,6 @@ public interface ChatRoomService {
 	/**
 	 * Top-N 페이징: 최신 메시지 기준으로 채팅방을 페이징 조회 (슬림 DTO)
 	 */
-    org.springframework.data.domain.Page<ChatRoomLatestMessageDto> getLatestMessagesPaged(Integer userId, org.springframework.data.domain.Pageable pageable);
+    org.springframework.data.domain.Page<ChatRoomLatestMessageDTO> getLatestMessagesPaged(Integer userId, org.springframework.data.domain.Pageable pageable);
 
 }

--- a/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
+++ b/backend/src/main/java/com/goodee/coreconnect/chat/service/ChatRoomServiceImpl.java
@@ -310,7 +310,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 	 */
 	@Transactional(readOnly = true)
 	@Override
-	public org.springframework.data.domain.Page<ChatRoomLatestMessageDto> getLatestMessagesPaged(Integer userId, org.springframework.data.domain.Pageable pageable) {
+	public org.springframework.data.domain.Page<ChatRoomLatestMessageDTO> getLatestMessagesPaged(Integer userId, org.springframework.data.domain.Pageable pageable) {
 	    // 사용자가 참여 중인 채팅방 id 목록 조회
 	    List<ChatRoomUser> chatRoomUsers = chatRoomUserRepository.findByUserId(userId);
 	    List<Integer> roomIds = chatRoomUsers.stream()
@@ -328,7 +328,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 	    return page.map(chat -> {
 	        ChatRoom room = chat.getChatRoom();
 	        User sender = chat.getSender();
-	        return ChatRoomLatestMessageDto.builder()
+	        return ChatRoomLatestMessageDTO.builder()
 	                .roomId(room != null ? room.getId() : null)
 	                .roomName(room != null ? room.getRoomName() : null)
 	                .lastMessageId(chat.getId())


### PR DESCRIPTION
Top-N 페이징 + 슬림 DTO 추가로 채팅방 최신 메시지 조회 시 쿼리/페이로드 경감
ChatRepository에 EntityGraph 적용하여 N+1 완화, 최신 메시지 페이징 메서드 추가
읽음 처리 비동기 이벤트(AsyncConfig, MessageReadEvent/Listener) 적용
GZIP 압축 활성화, HikariCP/Tomcat 부하 테스트용 튜닝, 인덱스 스크립트 가이드 추가

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the read-event listener to only update read status asynchronously and standardizes latest-messages paging to use `ChatRoomLatestMessageDTO`.
> 
> - **Backend · Chat**:
>   - **Read Event Handling**: `MessageReadEventListener` now only updates read status asynchronously; removes `NotificationService` dependency/calls and adds a TODO for optional unread-count handling.
>   - **Latest Messages Paging**: Unifies DTO to `ChatRoomLatestMessageDTO` in `ChatRoomService#getLatestMessagesPaged` and `ChatRoomServiceImpl` (method signature and builder).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b3230cc698e46d93f1c34e48a377ced7d499529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->