### PR TITLE
fix: 채팅 무한 스크롤 시 스크롤 위치 유지 개선

### DIFF
--- a/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
@@ -384,3 +384,7 @@ public class JMeterResultAnalyzer {
 
 
 
+
+
+
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
@@ -392,3 +392,7 @@ public class MetricsAnalyzer {
 
 
 
+
+
+
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
@@ -156,3 +156,7 @@ class PerformanceMetricsTest {
 
 
 
+
+
+
+

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -73,11 +73,30 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
   const scrollPositionRef = useRef({ scrollHeight: 0, scrollTop: 0 });
   const autoHideTimerRef = useRef(null);
   const unreadMarkerRef = useRef(null);
+  const isUserScrollingRef = useRef(false); // 사용자가 수동으로 스크롤 중인지 추적
+  const isNearBottomBeforeUpdateRef = useRef(true); // 메시지 추가 전에 스크롤이 하단 근처였는지 추적
+  const lastMessageIdRef = useRef(messages.length > 0 ? messages[messages.length - 1]?.id : null); // ⭐ 마지막 메시지 ID 추적
 
   // 무한 스크롤(위로 올릴 때 loadMore) - 스크롤 위치 유지
   const handleScroll = () => {
     const el = scrollRef.current;
     if (!el) return;
+    
+    // 스크롤이 하단 근처인지 확인 (50px 오차 허용)
+    const scrollTop = el.scrollTop;
+    const scrollHeight = el.scrollHeight;
+    const clientHeight = el.clientHeight;
+    const isNearBottom = scrollTop + clientHeight >= scrollHeight - 50;
+    
+    // 사용자가 수동으로 스크롤을 위로 올렸는지 추적
+    if (!isNearBottom) {
+      isUserScrollingRef.current = true;
+    } else {
+      isUserScrollingRef.current = false;
+    }
+    
+    // 다음 업데이트를 위해 현재 스크롤 위치 저장
+    isNearBottomBeforeUpdateRef.current = isNearBottom;
     
     // 이전 메시지 로드 (무한 스크롤)
     if (onLoadMore && hasMoreAbove && !loadingAbove && el.scrollTop <= 24) {
@@ -86,6 +105,9 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
         scrollHeight: el.scrollHeight,
         scrollTop: el.scrollTop,
       };
+      
+      // 사용자가 위로 스크롤 중임을 표시
+      isUserScrollingRef.current = true;
       
       // 이전 메시지 로드
       onLoadMore();
@@ -211,20 +233,66 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
     };
   }, [messages, showUnreadMarker, markerDismissed]);
 
-  // 새 메시지 오면 항상 맨 아래로 스크롤 (안읽은 메시지가 없고 scrollToUnread가 false일 때만)
+  // 새 메시지 오면 맨 아래로 스크롤 (조건부)
   useEffect(() => {
     const el = scrollRef.current;
-    if (el && messages.length > 0 && !scrollToUnread) {
-      // 안읽은 메시지가 없을 때만 자동 스크롤
-      if (firstUnreadIndex < 0) {
+    if (!el || messages.length === 0 || scrollToUnread) return;
+    
+    // ⭐ 핵심: 마지막 메시지 ID가 변경되었는지 확인 (새 메시지 추가 판단)
+    const currentLastMessageId = messages.length > 0 ? messages[messages.length - 1]?.id : null;
+    const isNewMessageAdded = currentLastMessageId !== lastMessageIdRef.current && currentLastMessageId !== null;
+    
+    // ⭐ 이전 메시지 로드 vs 새 메시지 추가 구분
+    // - 새 메시지 추가: 마지막 메시지 ID가 변경됨
+    // - 이전 메시지 로드: 마지막 메시지 ID는 그대로, 첫 번째 메시지 ID가 변경됨
+    
+    if (isNewMessageAdded) {
+      console.log("🆕 [ChatMessageList] 새 메시지 추가 감지:", {
+        previousLastId: lastMessageIdRef.current,
+        currentLastId: currentLastMessageId,
+        messagesLength: messages.length
+      });
+      
+      // 마지막 메시지 ID 업데이트
+      lastMessageIdRef.current = currentLastMessageId;
+      
+      // 새 메시지가 추가된 경우: 이전에 스크롤이 하단 근처였고, 사용자가 수동 스크롤 중이 아닐 때만 자동 스크롤
+      const shouldAutoScroll = isNearBottomBeforeUpdateRef.current && !isUserScrollingRef.current && firstUnreadIndex < 0;
+      
+      console.log("📊 [ChatMessageList] 자동 스크롤 조건 체크:", {
+        isNearBottomBefore: isNearBottomBeforeUpdateRef.current,
+        isUserScrolling: isUserScrollingRef.current,
+        firstUnreadIndex: firstUnreadIndex,
+        shouldAutoScroll: shouldAutoScroll
+      });
+      
+      if (shouldAutoScroll) {
         // ⭐ 스크롤을 맨 아래로 내리기 (약간의 지연을 두어 DOM 업데이트 완료 후 실행)
         setTimeout(() => {
           if (el) {
             el.scrollTop = el.scrollHeight;
+            isNearBottomBeforeUpdateRef.current = true;
+            console.log("✅ [ChatMessageList] 자동 스크롤 실행:", {
+              scrollTop: el.scrollTop,
+              scrollHeight: el.scrollHeight
+            });
           }
         }, 100);
+      } else {
+        console.log("🚫 [ChatMessageList] 자동 스크롤 건너뜀");
       }
+    } else if (messages.length > previousMessagesLengthRef.current) {
+      // 메시지 수는 증가했지만 마지막 메시지 ID는 그대로 → 이전 메시지 로드
+      console.log("📜 [ChatMessageList] 이전 메시지 로드 감지 (자동 스크롤 안 함):", {
+        messagesLength: messages.length,
+        previousLength: previousMessagesLengthRef.current,
+        lastMessageId: currentLastMessageId
+      });
     }
+    
+    // 메시지 수 업데이트
+    previousMessagesLengthRef.current = messages.length;
+    
   }, [messages, firstUnreadIndex, scrollToUnread]);
   
   // ⭐ 안읽은 메시지 위치로 스크롤 (채팅방 선택 시)


### PR DESCRIPTION


```markdown
## 📊 요약
이메일 받은편지함 조회 성능을 **88-90% 개선**했습니다.

- **응답시간**: 25-30ms → 2-3ms (88-90% ↓)
- **쿼리 수**: 21개 → 1개 (95% ↓)
- **스캔 행수**: 50,000 → 100 (99% ↓)

---

## 🔍 문제 배경

k6 부하테스트 결과, 이메일 API가 가장 느렸습니다:

| API | 응답시간 | 상태 |
|-----|---------|------|
| 알림 | 7ms | ✅ |
| 채팅 | 10ms | ✅ |
| **이메일** | **25-30ms** | 🔴 |

EXPLAIN 분석:
```sql
| type | rows   | Extra                    |
|------|--------|--------------------------|
| ALL  | 50,000 | Using where; Using filesort |
```

**3가지 병목**:
1. Full Table Scan (50,000 rows)
2. N+1 쿼리 (21개 쿼리 실행)
3. Using filesort (정렬 느림)

---

## ✅ 해결 방안

### 1. LEFT JOIN FETCH (N+1 방지)

**Before**:
```java
SELECT r FROM EmailRecipient r WHERE ...
// 1개 쿼리 + 20개 추가 쿼리 = 21개
```

**After**:
```java
SELECT r FROM EmailRecipient r 
LEFT JOIN FETCH r.email e  // ⭐
WHERE ...
// 1개 쿼리
```

### 2. NOT IN → = (인덱스 최적화)

**Before**:
```sql
WHERE email_status NOT IN ('TRASH', 'DELETED', 'DRAFT', 'RESERVED')
```

**After**:
```sql
WHERE email_status = 'SENT'
```

### 3. IS NULL OR 제거 (쿼리 단순화)

**Before**:
```sql
WHERE (deleted IS NULL OR deleted = false)
```

**After**:
```sql
WHERE deleted = false
```

---

## 📈 성능 개선 결과

### EXPLAIN 비교

| 항목 | Before | After |
|------|--------|-------|
| **type** | ALL | ref |
| **rows** | 50,000 | 100 |
| **Extra** | Using filesort | Using index |

### 실제 측정

| 지표 | Before | After | 개선율 |
|------|--------|-------|--------|
| 평균 응답시간 | 25-30ms | 2-3ms | ⬇️ 88-90% |
| P95 응답시간 | 45ms | 5ms | ⬇️ 89% |
| 쿼리 수 | 21개 | 1개 | ⬇️ 95% |
| 처리량 | 10 req/s | 30 req/s | ⬆️ 3배 |

---

## 🧪 테스트

1. **EXPLAIN 검증**
   - ✅ type: ref (Index Scan)
   - ✅ rows: 100 (99% 감소)

2. **MySQL PROFILING**
   - ✅ 0.028초 → 0.003초 (89% 개선)

3. **k6 부하테스트**
   - ✅ 45 VU, 2분간 안정적
   - ✅ 성공률 100%

---

## 🔧 영향받는 메서드

다음 5개 메서드를 최적화했습니다:

1. `findInboxExcludingTrash`
2. `findUnreadInboxExcludingTrash`
3. `findTodayInboxExcludingTrash`
4. `countUnreadInboxMails`
5. `countInboxMails`

---

## ⚠️ 주의사항

### 1. 이메일 상태 변경
- **Before**: NOT IN (...) - 모든 상태 조회
- **After**: = 'SENT' - SENT만 조회
- **확인**: ✅ 비즈니스 로직 검증 완료

### 2. deleted NULL 처리
- **Before**: (IS NULL OR = false)
- **After**: = false
- **대응**: ✅ JPA @Builder.Default 설정

### 3. Fetch Join 페이징
- **경고**: HHH000104 (메모리 페이징)
- **영향**: 20개씩 페이징 (미미함)

---

## 📝 체크리스트

### 코드
- [x] JPQL 쿼리 최적화 (5개 메서드)
- [x] Fetch Join 추가
- [x] 주석 추가

### 테스트
- [x] EXPLAIN 검증
- [x] PROFILING 측정
- [x] k6 부하테스트
- [x] 기능 테스트

### 배포
- [x] DB 인덱스 추가 (#124)
- [x] 데이터 마이그레이션 (#125)
- [x] 프로덕션 모니터링

---

## 🔗 관련 링크

- 📊 [k6 테스트 결과](https://choimeeyoung2.grafana.net/a/k6-app/runs/6342268)
- 📄 기술 문서: `이메일_받은편지함_쿼리_최적화_상세분석.md`
- 🎤 면접 답변: `이메일_쿼리_최적화_면접답변.md`