### PR TITLE
fix: 채팅 무한 스크롤 이전 메시지 로딩 개선

### DIFF
--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -98,8 +98,23 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
     // 다음 업데이트를 위해 현재 스크롤 위치 저장
     isNearBottomBeforeUpdateRef.current = isNearBottom;
     
-    // 이전 메시지 로드 (무한 스크롤)
-    if (onLoadMore && hasMoreAbove && !loadingAbove && el.scrollTop <= 24) {
+    // ⭐ 이전 메시지 로드 (무한 스크롤) - 조건 완화: 150px로 증가
+    // 스크롤이 상단 150px 이내에 있으면 이전 메시지 로드
+    const isNearTop = scrollTop <= 150;
+    
+    console.log("📏 [ChatMessageList] 스크롤 위치:", {
+      scrollTop: scrollTop,
+      scrollHeight: scrollHeight,
+      clientHeight: clientHeight,
+      isNearTop: isNearTop,
+      hasMoreAbove: hasMoreAbove,
+      loadingAbove: loadingAbove,
+      onLoadMore: !!onLoadMore
+    });
+    
+    if (onLoadMore && hasMoreAbove && !loadingAbove && isNearTop) {
+      console.log("🔄 [ChatMessageList] 이전 메시지 로드 시작");
+      
       // 현재 스크롤 위치와 높이 저장
       scrollPositionRef.current = {
         scrollHeight: el.scrollHeight,
@@ -135,26 +150,49 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
     }
   };
   
-  // 메시지가 추가되었을 때 스크롤 위치 복원
+  // ⭐ 이전 메시지 로드 시 스크롤 위치 복원
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el || loadingAbove) return;
+    if (!el) return;
     
     // 이전 메시지가 추가된 경우 (메시지 수가 증가하고 스크롤이 위쪽에 있을 때)
     const messagesIncreased = messages.length > previousMessagesLengthRef.current;
-    const isScrolledToTop = el.scrollTop < 100;
+    const isScrolledToTop = el.scrollTop < 300; // 300px 이하면 상단으로 간주
+    
+    console.log("📐 [ChatMessageList] 스크롤 위치 복원 체크:", {
+      messagesLength: messages.length,
+      previousLength: previousMessagesLengthRef.current,
+      messagesIncreased: messagesIncreased,
+      isScrolledToTop: isScrolledToTop,
+      scrollTop: el.scrollTop,
+      savedScrollHeight: scrollPositionRef.current.scrollHeight,
+      loadingAbove: loadingAbove
+    });
     
     if (messagesIncreased && isScrolledToTop && scrollPositionRef.current.scrollHeight > 0) {
       const newScrollHeight = el.scrollHeight;
       const heightDiff = newScrollHeight - scrollPositionRef.current.scrollHeight;
       
-      // 스크롤 위치 복원
-      setTimeout(() => {
+      console.log("✅ [ChatMessageList] 스크롤 위치 복원 실행:", {
+        이전scrollHeight: scrollPositionRef.current.scrollHeight,
+        새로운scrollHeight: newScrollHeight,
+        heightDiff: heightDiff,
+        이전scrollTop: scrollPositionRef.current.scrollTop,
+        새로운scrollTop: scrollPositionRef.current.scrollTop + heightDiff
+      });
+      
+      // 스크롤 위치 복원 (즉시 실행)
+      requestAnimationFrame(() => {
         if (el) {
-          el.scrollTop = scrollPositionRef.current.scrollTop + heightDiff;
+          const newScrollTop = scrollPositionRef.current.scrollTop + heightDiff;
+          el.scrollTop = newScrollTop;
+          console.log("📍 [ChatMessageList] 스크롤 위치 설정 완료:", {
+            설정한위치: newScrollTop,
+            실제위치: el.scrollTop
+          });
           scrollPositionRef.current = { scrollHeight: 0, scrollTop: 0 }; // 초기화
         }
-      }, 0);
+      });
     }
     
     previousMessagesLengthRef.current = messages.length;

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1503,8 +1503,27 @@ export default function ChatLayout() {
 
   // ---------- 이전 메시지 로딩 (무한 스크롤) ----------
   const handleLoadMoreMessages = async () => {
-    if (!selectedRoomId || isLoadingMore || !hasMore) return;
+    console.log("🔄 [ChatLayout] handleLoadMoreMessages 호출:", {
+      selectedRoomId: selectedRoomId,
+      isLoadingMore: isLoadingMore,
+      hasMore: hasMore,
+      currentPage: currentPage
+    });
+    
+    if (!selectedRoomId || isLoadingMore || !hasMore) {
+      console.log("🚫 [ChatLayout] 이전 메시지 로드 중단:", {
+        selectedRoomId: !!selectedRoomId,
+        isLoadingMore: isLoadingMore,
+        hasMore: hasMore
+      });
+      return;
+    }
 
+    console.log("✅ [ChatLayout] 이전 메시지 로드 시작:", {
+      currentPage: currentPage,
+      nextPage: currentPage + 1
+    });
+    
     setIsLoadingMore(true);
 
     // 스크롤 위치 저장을 위한 ref (ChatMessageList에서 접근 가능하도록)
@@ -1519,7 +1538,18 @@ export default function ChatLayout() {
 
     try {
       const nextPage = currentPage + 1;
+      console.log("📡 [ChatLayout] API 호출:", {
+        roomId: selectedRoomId,
+        page: nextPage,
+        size: 20
+      });
+      
       const res = await fetchChatRoomMessages(selectedRoomId, nextPage, 20);
+      
+      console.log("📥 [ChatLayout] API 응답 받음:", {
+        hasData: !!res?.data,
+        dataStructure: res?.data ? Object.keys(res.data) : []
+      });
 
       if (res && res.data) {
         // ResponseDTO 구조: { status, message, data: Page<ChatMessageResponseDTO> }
@@ -1703,16 +1733,35 @@ export default function ChatLayout() {
               });
             }
 
+            console.log("✅ [ChatLayout] 이전 메시지 병합 완료:", {
+              추가된메시지수: trulyNewMessages.length,
+              기존메시지수: prev.length,
+              전체메시지수: trulyNewMessages.length + merged.length
+            });
+            
             return [...trulyNewMessages, ...merged];
           });
+          
           setTotalPages(pageData.totalPages || 0);
           setHasMore(!pageData.last);
           setCurrentPage(nextPage);
+          
+          console.log("✅ [ChatLayout] 페이지 상태 업데이트 완료:", {
+            totalPages: pageData.totalPages,
+            currentPage: nextPage,
+            hasMore: !pageData.last,
+            isLast: pageData.last
+          });
+        } else {
+          console.warn("⚠️ [ChatLayout] pageData.content가 배열이 아님:", pageData);
         }
+      } else {
+        console.warn("⚠️ [ChatLayout] res.data가 없음:", res);
       }
     } catch (error) {
-      console.error("이전 메시지 로딩 실패:", error);
+      console.error("❌ [ChatLayout] 이전 메시지 로딩 실패:", error);
     } finally {
+      console.log("🏁 [ChatLayout] 로딩 상태 false로 변경");
       setIsLoadingMore(false);
     }
   };


### PR DESCRIPTION
- 스크롤 감지 영역 확대 (24px → 150px)
- 스크롤 위치 복원 로직 개선 (requestAnimationFrame 사용)
- 상세한 디버깅 로그 추가
- 사용자가 위로 스크롤 시 이전 메시지가 제대로 로드되도록 개선