### PR TITLE
fix: 채팅 무한 스크롤 UX 개선 - 이전 메시지 로드 시 스크롤 위치 유지

### DIFF
--- a/frontend/src/features/chat/components/ChatDetailPane.jsx
+++ b/frontend/src/features/chat/components/ChatDetailPane.jsx
@@ -21,14 +21,52 @@ function ChatDetailPane({
   onLeaveRoom // 채팅방 나가기 콜백
 }) {
   const messagesEndRef = useRef(null);
+  const previousMessageCountRef = useRef(0);
   const [participantsDialogOpen, setParticipantsDialogOpen] = useState(false);
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const [participants, setParticipants] = useState([]);
   const [menuAnchorEl, setMenuAnchorEl] = useState(null);
   const menuOpen = Boolean(menuAnchorEl);
 
+  // ⭐ 채팅방 변경 시에만 맨 아래로 스크롤 (초기 진입)
   useEffect(() => {
-    if (messagesEndRef.current) messagesEndRef.current.scrollIntoView({behavior: "smooth"});
+    if (messagesEndRef.current && selectedRoom?.roomId) {
+      console.log("🏠 [ChatDetailPane] 채팅방 변경 - 맨 아래로 스크롤");
+      messagesEndRef.current.scrollIntoView({behavior: "smooth"});
+      previousMessageCountRef.current = messages.length;
+    }
+  }, [selectedRoom?.roomId]);
+
+  // ⭐ 메시지 추가 시 조건부 스크롤 (스크롤이 맨 아래에 있을 때만)
+  useEffect(() => {
+    const scrollContainer = document.querySelector('.chat-message-list-container');
+    if (!scrollContainer || !messagesEndRef.current) return;
+
+    const isNewMessage = messages.length > previousMessageCountRef.current;
+    
+    if (isNewMessage) {
+      const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+      const isNearBottom = scrollHeight - scrollTop - clientHeight < 150; // 150px 이내면 맨 아래로 간주
+      
+      console.log("📨 [ChatDetailPane] 새 메시지 감지:", {
+        messagesLength: messages.length,
+        previousCount: previousMessageCountRef.current,
+        scrollTop: scrollTop,
+        scrollHeight: scrollHeight,
+        clientHeight: clientHeight,
+        distanceFromBottom: scrollHeight - scrollTop - clientHeight,
+        isNearBottom: isNearBottom
+      });
+      
+      if (isNearBottom) {
+        console.log("✅ [ChatDetailPane] 스크롤이 맨 아래 근처 - 자동 스크롤 실행");
+        messagesEndRef.current.scrollIntoView({behavior: "smooth"});
+      } else {
+        console.log("🚫 [ChatDetailPane] 스크롤이 위쪽 - 자동 스크롤 건너뜀");
+      }
+    }
+    
+    previousMessageCountRef.current = messages.length;
   }, [messages]);
 
   // 참여자 목록 조회


### PR DESCRIPTION
- ChatDetailPane: messages 변경 시 무조건 하단 스크롤 문제 해결
- ChatMessageList: 무한 스크롤 감지 및 복원 로직 개선
- ChatLayout: 이전 메시지 로딩 디버깅 로그 추가


수정된 파일
frontend/src/features/chat/components/ChatDetailPane.jsx
previousMessageCountRef ref 추가
채팅방 변경 시에만 강제 스크롤 (초기 진입)
메시지 추가 시 조건부 스크롤 (하단 150px 이내)
상세한 디버깅 로그 추가
frontend/src/features/chat/components/ChatMessageList.jsx
스크롤 감지 영역 확대 (24px → 150px)
lastMessageIdRef ref 추가로 새 메시지/이전 메시지 구분
requestAnimationFrame으로 스크롤 위치 복원 개선
상세한 디버깅 로그 추가
frontend/src/features/chat/pages/ChatLayout.jsx
이전 메시지 로딩 과정 디버깅 로그 추가
API 호출, 응답, 병합 과정 추적


📊 테스트 시나리오
✅ 시나리오 1: 채팅방 변경 (초기 진입)
동작: 채팅방 A → 채팅방 B 클릭
결과: 맨 아래로 스크롤 ✅
의존성: selectedRoom.roomId 변경
✅ 시나리오 2: 이전 메시지 로드
동작: 위로 스크롤 → 최상단 근처 도달
결과:
"불러오는 중..." 표시 ✅
이전 메시지 로드 ✅
스크롤 위치 유지 (하단으로 이동 안 함) ✅
로그: 🚫 스크롤이 위쪽 - 자동 스크롤 건너뜀
✅ 시나리오 3: 맨 아래에서 새 메시지 수신
동작: 맨 아래까지 스크롤된 상태에서 새 메시지 도착
결과: 자동으로 맨 아래 스크롤 ✅
로그: ✅ 스크롤이 맨 아래 근처 - 자동 스크롤 실행
✅ 시나리오 4: 중간에서 새 메시지 수신
동작: 이전 대화를 보는 중 새 메시지 도착
결과: 스크롤 위치 유지 (방해하지 않음) ✅
로그: 🚫 스크롤이 위쪽 - 자동 스크롤 건너뜀