### PR TITLE
fix: 무한 스크롤 완전 수정 - isInitialLoadRef로 초기 로드와 무한 스크롤 구분

### DIFF
--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -155,50 +155,10 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
   };
   
   // ⭐ 이전 메시지 로드 시 스크롤 위치 복원
+  // ✅ 수정: ChatLayout에서 스크롤 위치 복원을 처리하므로 여기서는 단순히 메시지 수만 추적
   useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    
-    // 이전 메시지가 추가된 경우 (메시지 수가 증가하고 저장된 스크롤 위치가 있을 때)
-    const messagesIncreased = messages.length > previousMessagesLengthRef.current;
-    
-    console.log("📐 [ChatMessageList] 스크롤 위치 복원 체크:", {
-      messagesLength: messages.length,
-      previousLength: previousMessagesLengthRef.current,
-      messagesIncreased: messagesIncreased,
-      scrollTop: el.scrollTop,
-      savedScrollHeight: scrollPositionRef.current.scrollHeight,
-      loadingAbove: loadingAbove
-    });
-    
-    // ✅ 수정: 조건을 더 명확하게 - 저장된 스크롤 위치가 있으면 무조건 복원
-    if (messagesIncreased && scrollPositionRef.current.scrollHeight > 0) {
-      const newScrollHeight = el.scrollHeight;
-      const heightDiff = newScrollHeight - scrollPositionRef.current.scrollHeight;
-      
-      console.log("✅ [ChatMessageList] 스크롤 위치 복원 실행:", {
-        이전scrollHeight: scrollPositionRef.current.scrollHeight,
-        새로운scrollHeight: newScrollHeight,
-        heightDiff: heightDiff,
-        이전scrollTop: scrollPositionRef.current.scrollTop,
-        새로운scrollTop: scrollPositionRef.current.scrollTop + heightDiff
-      });
-      
-      // ✅ 스크롤 위치 복원 (즉시 실행, requestAnimationFrame 제거)
-      const newScrollTop = scrollPositionRef.current.scrollTop + heightDiff;
-      el.scrollTop = newScrollTop;
-      
-      console.log("📍 [ChatMessageList] 스크롤 위치 설정 완료:", {
-        설정한위치: newScrollTop,
-        실제위치: el.scrollTop
-      });
-      
-      // ✅ 초기화
-      scrollPositionRef.current = { scrollHeight: 0, scrollTop: 0 };
-    }
-    
     previousMessagesLengthRef.current = messages.length;
-  }, [messages.length, loadingAbove]);
+  }, [messages.length]);
 
   // 첫 번째 안읽은 메시지 인덱스 찾기
   useEffect(() => {
@@ -436,28 +396,8 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
     setTimeout(() => scrollToMarker(), 300);
   }, [scrollToUnread, firstUnreadIndex, messages.length, onScrollToUnreadComplete]);
 
-  // ⭐ 채팅방 선택 시 메시지 로드 후 최신 메시지로 스크롤 (안읽은 메시지가 없을 때만)
-  // onMessagesLoaded prop이 호출되면 스크롤을 맨 아래로 이동
-  // ✅ 수정: messages.length 의존성 제거 → 채팅방 변경 시에만 실행되도록
-  useEffect(() => {
-    if (onMessagesLoaded && messages.length > 0 && firstUnreadIndex < 0) {
-      const el = scrollRef.current;
-      if (el) {
-        // DOM 업데이트 완료 후 스크롤 (약간의 지연)
-        setTimeout(() => {
-          if (el) {
-            el.scrollTop = el.scrollHeight;
-            console.log("📜 [ChatMessageList] 채팅방 선택 시 최신 메시지로 스크롤:", {
-              scrollTop: el.scrollTop,
-              scrollHeight: el.scrollHeight,
-              messagesLength: messages.length
-            });
-          }
-        }, 200);
-      }
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onMessagesLoaded, firstUnreadIndex]); // ⚠️ messages.length 제거! (의도적으로 제외)
+  // ❌ 제거: ChatLayout에서 초기 스크롤을 처리하므로 이 로직은 불필요하고 간섭함
+  // ⭐ onMessagesLoaded 로직 완전 제거 (ChatLayout의 isInitialLoadRef로 대체)
 
   return (
     <Box

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -103,6 +103,7 @@ export default function ChatLayout() {
 
   const userName = userProfile?.name || ""; // 유저명
   const inputRef = useRef(); // 입력창 관리 ref
+  const isInitialLoadRef = useRef(true); // ✅ 초기 로드 여부 추적 (무한 스크롤과 구분)
 
   const [socketConnected, setSocketConnected] = useState(false); // 소켓 연결 상태
 
@@ -1262,6 +1263,9 @@ export default function ChatLayout() {
   useEffect(() => {
     async function loadMessages() {
       if (selectedRoomId) {
+        // ✅ 초기 로드 플래그 설정
+        isInitialLoadRef.current = true;
+        
         // 채팅방이 변경되면 페이징 상태 초기화
         setCurrentPage(0);
         setHasMore(true);
@@ -1478,20 +1482,29 @@ export default function ChatLayout() {
             setCurrentPage(0);
 
             // ⭐ 채팅방 선택 시 메시지 로드 후 스크롤 처리
-            // scrollToUnread가 true이면 ChatMessageList에서 처리하므로 여기서는 스크롤하지 않음
-            // scrollToUnread가 false일 때만 최신 메시지로 스크롤
-            if (!scrollToUnread) {
+            // ✅ 수정: 초기 로드일 때만 스크롤 (무한 스크롤 시에는 스크롤 안 함)
+            if (isInitialLoadRef.current && !scrollToUnread) {
               setTimeout(() => {
                 const scrollContainer = document.querySelector('.chat-message-list-container');
                 if (scrollContainer) {
                   scrollContainer.scrollTop = scrollContainer.scrollHeight;
-                  console.log("📜 [ChatLayout] 채팅방 선택 시 최신 메시지로 스크롤:", {
+                  console.log("📜 [ChatLayout] ✅ 초기 로드 - 최신 메시지로 스크롤:", {
                     scrollTop: scrollContainer.scrollTop,
                     scrollHeight: scrollContainer.scrollHeight,
-                    messagesLength: messagesWithPendingUpdates.length
+                    messagesLength: messagesWithPendingUpdates.length,
+                    isInitialLoad: isInitialLoadRef.current
                   });
                 }
+                // ✅ 초기 로드 플래그 해제
+                isInitialLoadRef.current = false;
               }, 300);
+            } else {
+              console.log("📜 [ChatLayout] ⏭️ 초기 로드 아님 - 스크롤 안 함:", {
+                isInitialLoad: isInitialLoadRef.current,
+                scrollToUnread: scrollToUnread
+              });
+              // ✅ 초기 로드 플래그 해제
+              isInitialLoadRef.current = false;
             }
 
             // ⭐ 채팅방 접속 시 안읽은 메시지들을 읽음 처리
@@ -1574,7 +1587,8 @@ export default function ChatLayout() {
       selectedRoomId: selectedRoomId,
       isLoadingMore: isLoadingMore,
       hasMore: hasMore,
-      currentPage: currentPage
+      currentPage: currentPage,
+      isInitialLoad: isInitialLoadRef.current // ✅ 로그 추가
     });
     
     if (!selectedRoomId || isLoadingMore || !hasMore) {
@@ -1591,16 +1605,23 @@ export default function ChatLayout() {
       nextPage: currentPage + 1
     });
     
+    // ✅ 초기 로드가 아님을 명시
+    isInitialLoadRef.current = false;
+    
     setIsLoadingMore(true);
 
-    // 스크롤 위치 저장을 위한 ref (ChatMessageList에서 접근 가능하도록)
-    const scrollContainerRef = document.querySelector('.chat-message-list-container');
+    // ✅ 스크롤 위치 저장 (복원을 위해)
+    const scrollContainer = document.querySelector('.chat-message-list-container');
     let scrollHeightBefore = 0;
     let scrollTopBefore = 0;
 
-    if (scrollContainerRef) {
-      scrollHeightBefore = scrollContainerRef.scrollHeight;
-      scrollTopBefore = scrollContainerRef.scrollTop;
+    if (scrollContainer) {
+      scrollHeightBefore = scrollContainer.scrollHeight;
+      scrollTopBefore = scrollContainer.scrollTop;
+      console.log("💾 [ChatLayout] 스크롤 위치 저장:", {
+        scrollHeightBefore,
+        scrollTopBefore
+      });
     }
 
     try {
@@ -1819,6 +1840,26 @@ export default function ChatLayout() {
             hasMore: !pageData.last,
             isLast: pageData.last
           });
+          
+          // ✅ 스크롤 위치 복원 (메시지 추가 후)
+          setTimeout(() => {
+            if (scrollContainer) {
+              const scrollHeightAfter = scrollContainer.scrollHeight;
+              const heightDiff = scrollHeightAfter - scrollHeightBefore;
+              const newScrollTop = scrollTopBefore + heightDiff;
+              
+              scrollContainer.scrollTop = newScrollTop;
+              
+              console.log("📍 [ChatLayout] 스크롤 위치 복원:", {
+                scrollHeightBefore,
+                scrollHeightAfter,
+                heightDiff,
+                scrollTopBefore,
+                newScrollTop,
+                실제scrollTop: scrollContainer.scrollTop
+              });
+            }
+          }, 100);
         } else {
           console.warn("⚠️ [ChatLayout] pageData.content가 배열이 아님:", pageData);
         }


### PR DESCRIPTION
핵심 수정:
1. ChatLayout에 isInitialLoadRef 추가 - 초기 로드와 무한 스크롤 명확히 구분
2. 초기 로드일 때만 맨 아래로 스크롤, 무한 스크롤 시에는 스크롤 안 함
3. ChatLayout에서 스크롤 위치 저장/복원 처리 (100ms 지연)
4. ChatMessageList의 중복 스크롤 로직 제거

Before:
- 채팅방 진입 시와 무한 스크롤을 구분할 수 없음 ❌
- ChatMessageList와 ChatLayout이 모두 스크롤 처리 → 충돌 ❌
- 이전 메시지 로드 시 맨 아래로 이동 ❌

After:
- isInitialLoadRef로 명확히 구분 ✅
- ChatLayout에서 일관되게 처리 ✅
- 이전 메시지 로드 시 스크롤 위치 완벽 유지 ✅

Resolves: 이전 메시지를 계속 불러올 때 스크롤이
최신 메시지(맨 아래)로 자동 이동하는 문제