### PR TITLE
fix: ChatDetailPane 스크롤 간섭 로직 완전 제거

### DIFF
--- a/frontend/src/features/chat/components/ChatDetailPane.jsx
+++ b/frontend/src/features/chat/components/ChatDetailPane.jsx
@@ -20,54 +20,14 @@ function ChatDetailPane({
   onMarkAllAsRead, // 모두 읽음 처리 함수
   onLeaveRoom // 채팅방 나가기 콜백
 }) {
-  const messagesEndRef = useRef(null);
-  const previousMessageCountRef = useRef(0);
   const [participantsDialogOpen, setParticipantsDialogOpen] = useState(false);
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const [participants, setParticipants] = useState([]);
   const [menuAnchorEl, setMenuAnchorEl] = useState(null);
   const menuOpen = Boolean(menuAnchorEl);
 
-  // ⭐ 채팅방 변경 시에만 맨 아래로 스크롤 (초기 진입)
-  useEffect(() => {
-    if (messagesEndRef.current && selectedRoom?.roomId) {
-      console.log("🏠 [ChatDetailPane] 채팅방 변경 - 맨 아래로 스크롤");
-      messagesEndRef.current.scrollIntoView({behavior: "smooth"});
-      previousMessageCountRef.current = messages.length;
-    }
-  }, [selectedRoom?.roomId]);
-
-  // ⭐ 메시지 추가 시 조건부 스크롤 (스크롤이 맨 아래에 있을 때만)
-  useEffect(() => {
-    const scrollContainer = document.querySelector('.chat-message-list-container');
-    if (!scrollContainer || !messagesEndRef.current) return;
-
-    const isNewMessage = messages.length > previousMessageCountRef.current;
-    
-    if (isNewMessage) {
-      const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
-      const isNearBottom = scrollHeight - scrollTop - clientHeight < 150; // 150px 이내면 맨 아래로 간주
-      
-      console.log("📨 [ChatDetailPane] 새 메시지 감지:", {
-        messagesLength: messages.length,
-        previousCount: previousMessageCountRef.current,
-        scrollTop: scrollTop,
-        scrollHeight: scrollHeight,
-        clientHeight: clientHeight,
-        distanceFromBottom: scrollHeight - scrollTop - clientHeight,
-        isNearBottom: isNearBottom
-      });
-      
-      if (isNearBottom) {
-        console.log("✅ [ChatDetailPane] 스크롤이 맨 아래 근처 - 자동 스크롤 실행");
-        messagesEndRef.current.scrollIntoView({behavior: "smooth"});
-      } else {
-        console.log("🚫 [ChatDetailPane] 스크롤이 위쪽 - 자동 스크롤 건너뜀");
-      }
-    }
-    
-    previousMessageCountRef.current = messages.length;
-  }, [messages]);
+  // ❌ 제거: ChatLayout에서 스크롤을 관리하므로 여기서는 스크롤하지 않음
+  // ChatDetailPane은 단순히 메시지를 표시만 하고, 스크롤 제어는 ChatLayout의 isInitialLoadRef로 처리
 
   // 참여자 목록 조회
   useEffect(() => {
@@ -200,7 +160,6 @@ function ChatDetailPane({
         scrollToUnread={scrollToUnread}
         onScrollToUnreadComplete={onScrollToUnreadComplete}
       />
-      <div ref={messagesEndRef} />
       <ChatMessageInputBox
         inputRef={inputRef}
         onSend={onSend}

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -83,6 +83,9 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
     const el = scrollRef.current;
     if (!el) return;
     
+    // ⭐ 디버깅: handleScroll 호출 확인
+    console.log("🖱️ [ChatMessageList] handleScroll 호출");
+    
     // 스크롤이 하단 근처인지 확인 (50px 오차 허용)
     const scrollTop = el.scrollTop;
     const scrollHeight = el.scrollHeight;


### PR DESCRIPTION
- messagesEndRef, previousMessageCountRef 제거
- 채팅방 변경 시 스크롤 로직 제거
- 메시지 추가 시 조건부 스크롤 로직 제거
- 스크롤 제어는 ChatLayout에서만 관리

Before:
- ChatDetailPane이 messages 변경 시마다 스크롤 시도 ❌
- ChatLayout과 충돌 ❌

After:
- ChatDetailPane은 표시만 담당 ✅
- ChatLayout이 일관되게 스크롤 관리 ✅

Resolves: 무한 스크롤 시 ChatDetailPane이 스크롤을
강제로 내리는 문제