### PR TITLE
fix: ChatMessageList 자동 스크롤 로직 완전 제거

### DIFF
--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -75,8 +75,6 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
   const unreadMarkerRef = useRef(null);
   const isUserScrollingRef = useRef(false); // 사용자가 수동으로 스크롤 중인지 추적
   const isNearBottomBeforeUpdateRef = useRef(true); // 메시지 추가 전에 스크롤이 하단 근처였는지 추적
-  const lastMessageIdRef = useRef(messages.length > 0 ? messages[messages.length - 1]?.id : null); // ⭐ 마지막 메시지 ID 추적
-  const firstMessageIdRef = useRef(messages.length > 0 ? messages[0]?.id : null); // ⭐ 첫 번째 메시지 ID 추적 (이전 메시지 로드 감지용)
 
   // 무한 스크롤(위로 올릴 때 loadMore) - 스크롤 위치 유지
   const handleScroll = () => {
@@ -246,74 +244,8 @@ function ChatMessageList({ messages, roomType = "group", onLoadMore, hasMoreAbov
     };
   }, [messages, showUnreadMarker, markerDismissed]);
 
-  // 새 메시지 오면 맨 아래로 스크롤 (조건부)
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || messages.length === 0 || scrollToUnread) return;
-    
-    // ⭐ 핵심: 마지막 메시지 ID와 첫 번째 메시지 ID로 구분
-    const currentLastMessageId = messages.length > 0 ? messages[messages.length - 1]?.id : null;
-    const currentFirstMessageId = messages.length > 0 ? messages[0]?.id : null;
-    
-    const isNewMessageAdded = currentLastMessageId !== lastMessageIdRef.current && currentLastMessageId !== null;
-    const isOldMessageLoaded = currentFirstMessageId !== firstMessageIdRef.current && currentFirstMessageId !== null;
-    
-    // ✅ 이전 메시지 로드와 새 메시지 추가를 명확히 구분
-    if (isNewMessageAdded && !isOldMessageLoaded) {
-      // ✅ 새 메시지만 추가된 경우 (이전 메시지 로드가 아닌 경우)
-      console.log("🆕 [ChatMessageList] 새 메시지 추가 감지:", {
-        previousLastId: lastMessageIdRef.current,
-        currentLastId: currentLastMessageId,
-        firstMessageId: currentFirstMessageId,
-        previousFirstMessageId: firstMessageIdRef.current,
-        isOldMessageLoaded: isOldMessageLoaded
-      });
-      
-      // 마지막 메시지 ID 업데이트
-      lastMessageIdRef.current = currentLastMessageId;
-      firstMessageIdRef.current = currentFirstMessageId;
-      
-      // 새 메시지가 추가된 경우: 이전에 스크롤이 하단 근처였고, 사용자가 수동 스크롤 중이 아닐 때만 자동 스크롤
-      const shouldAutoScroll = isNearBottomBeforeUpdateRef.current && !isUserScrollingRef.current;
-      
-      console.log("📊 [ChatMessageList] 자동 스크롤 조건 체크:", {
-        isNearBottomBefore: isNearBottomBeforeUpdateRef.current,
-        isUserScrolling: isUserScrollingRef.current,
-        shouldAutoScroll: shouldAutoScroll
-      });
-      
-      if (shouldAutoScroll) {
-        // ⭐ 스크롤을 맨 아래로 내리기
-        setTimeout(() => {
-          if (el) {
-            el.scrollTop = el.scrollHeight;
-            isNearBottomBeforeUpdateRef.current = true;
-            console.log("✅ [ChatMessageList] 자동 스크롤 실행 (새 메시지):", {
-              scrollTop: el.scrollTop,
-              scrollHeight: el.scrollHeight
-            });
-          }
-        }, 100);
-      } else {
-        console.log("🚫 [ChatMessageList] 자동 스크롤 건너뜀 (사용자가 스크롤 중)");
-      }
-    } else if (isOldMessageLoaded) {
-      // ✅ 이전 메시지 로드된 경우 (자동 스크롤 안 함)
-      console.log("📜 [ChatMessageList] 이전 메시지 로드 감지 (자동 스크롤 안 함):", {
-        firstMessageId: currentFirstMessageId,
-        previousFirstMessageId: firstMessageIdRef.current,
-        lastMessageId: currentLastMessageId,
-        messagesLength: messages.length
-      });
-      
-      // ID 업데이트
-      firstMessageIdRef.current = currentFirstMessageId;
-      if (isNewMessageAdded) {
-        lastMessageIdRef.current = currentLastMessageId;
-      }
-    }
-    
-  }, [messages, firstUnreadIndex, scrollToUnread]);
+  // ❌ 완전 제거: ChatLayout에서 스크롤을 관리하므로 여기서는 절대 스크롤하지 않음
+  // ChatMessageList는 단순히 메시지를 표시하고 스크롤 이벤트를 감지하는 역할만 수행
   
   // ⭐ 안읽은 메시지 위치로 스크롤 (채팅방 선택 시)
   useEffect(() => {

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1482,8 +1482,16 @@ export default function ChatLayout() {
             setCurrentPage(0);
 
             // ⭐ 채팅방 선택 시 메시지 로드 후 스크롤 처리
-            // ✅ 수정: 초기 로드일 때만 스크롤 (무한 스크롤 시에는 스크롤 안 함)
+            // ✅ 수정: 초기 로드일 때만 스크롤 (무한 스크롤 시에는 절대 스크롤 안 함)
+            console.log("🔍 [ChatLayout] 스크롤 처리 체크:", {
+              isInitialLoad: isInitialLoadRef.current,
+              scrollToUnread: scrollToUnread,
+              messagesLength: messagesWithPendingUpdates.length
+            });
+            
             if (isInitialLoadRef.current && !scrollToUnread) {
+              // ⭐ 초기 로드일 때만 스크롤
+              console.log("✅ [ChatLayout] 초기 로드 확인 - 스크롤 예정");
               setTimeout(() => {
                 const scrollContainer = document.querySelector('.chat-message-list-container');
                 if (scrollContainer) {
@@ -1497,9 +1505,10 @@ export default function ChatLayout() {
                 }
                 // ✅ 초기 로드 플래그 해제
                 isInitialLoadRef.current = false;
+                console.log("🏁 [ChatLayout] isInitialLoadRef를 false로 설정");
               }, 300);
             } else {
-              console.log("📜 [ChatLayout] ⏭️ 초기 로드 아님 - 스크롤 안 함:", {
+              console.log("🚫 [ChatLayout] 초기 로드 아님 - 스크롤 안 함:", {
                 isInitialLoad: isInitialLoadRef.current,
                 scrollToUnread: scrollToUnread
               });


### PR DESCRIPTION
- lastMessageIdRef, firstMessageIdRef 제거
- 새 메시지 감지 및 자동 스크롤 useEffect 완전 제거
- ChatLayout에 상세한 디버깅 로그 추가
- 스크롤 제어는 ChatLayout에서만 관리

Before:
- ChatMessageList가 messages 변경 시마다 스크롤 시도 ❌
- isNearBottomBeforeUpdateRef 초기값 true로 인한 자동 스크롤 ❌

After:
- ChatMessageList는 handleScroll만 담당 ✅
- ChatLayout이 isInitialLoadRef로 완전 제어 ✅

Resolves: 무한 스크롤 시 ChatMessageList가 자동으로
맨 아래로 스크롤하는 문제