### PR TITLE
fix: 채팅 무한 스크롤 시 스크롤 위치 유지

### DIFF
--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1730,11 +1730,8 @@ export default function ChatLayout() {
     };
   }, [selectedRoomId]);
 
-  // ---------- 메시지 박스 끝으로 스크롤 ----------
-  const messagesEndRef = useRef(null);
-  useEffect(() => {
-    if (messagesEndRef.current) messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
+  // ❌ 제거: messages 변경 시 자동 스크롤 (무한 스크롤 방해)
+  // 초기 접속 시 스크롤은 초기 로드 useEffect에서 처리
 
   // ⭐ 디버깅: messages 상태 변경 추적 (필요시 주석 해제)
   useEffect(() => {


### PR DESCRIPTION
[문제 상황]
- 채팅방에서 스크롤을 위로 올려 이전 메시지 로드 시 스크롤이 최신 메시지로 자동 이동
- 사용자가 보던 위치를 잃어버려 이전 대화 확인 불가
- messages 상태 변경 시마다 자동 스크롤 발생

[원인 분석]
1. ChatLayout.jsx: useEffect([messages])에서 messagesEndRef.scrollIntoView() 호출
   → messages 변경마다 맨 아래로 강제 스크롤
2. ChatDetailPane.jsx: messages 변경 시 조건부 스크롤 로직
   → 무한 스크롤과 충돌
3. ChatMessageList.jsx: 새 메시지 감지 시 자동 스크롤 로직
   → 이전 메시지 로드를 새 메시지로 오인

[해결 방법]
1. ChatLayout.jsx
   - handleLoadMoreMessages 간소화 및 스크롤 위치 복원 로직 추가
     * 스크롤 위치 저장: before = { scrollTop, scrollHeight }
     * 메시지 prepend: setMessages(prev => [...newMessages, ...prev])
     * 스크롤 위치 복원: el.scrollTop = before.scrollTop + heightDiff
   - messages 변경 시 자동 스크롤 useEffect 완전 제거
   - 초기 접속 시에만 최신 메시지로 스크롤 (isInitialLoadRef 활용)

2. ChatMessageList.jsx
   - 모든 자동 스크롤 로직 제거
   - handleScroll에서 onLoadMore() 호출만 담당
   - hasScroll 조건 추가 (스크롤이 실제 존재할 때만 무한 스크롤)

3. ChatDetailPane.jsx
   - 모든 스크롤 관련 로직 제거
   - 순수하게 메시지 표시만 담당

[결과]
✅ 채팅방 처음 접속 시: 최신 메시지로 자동 스크롤 (UX 유지)
✅ 무한 스크롤 시: 스크롤 위치 정확히 유지 (heightDiff 보정)
✅ 스크롤 관리 일원화: ChatLayout에서만 제어

[기술 세부사항]
- setTimeout(0ms)으로 DOM 업데이트 후 스크롤 복원 보장
- isInitialLoadRef로 초기 접속과 무한 스크롤 구분
- prepend 방식으로 이전 메시지 추가 (오름차순 유지)
