### PR TITLE
fix: keep scroll position when prepending older chat messages

### DIFF
--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1598,11 +1598,6 @@ export default function ChatLayout() {
   const handleLoadMoreMessages = async () => {
     // 중복 호출/끝 페이지/선택 방 없음 차단
     if (!selectedRoomId || isLoadingMore || !hasMore) {
-      console.log("🚫 [ChatLayout] 이전 메시지 로드 차단:", {
-        selectedRoomId: !!selectedRoomId,
-        isLoadingMore,
-        hasMore
-      });
       return;
     }
 
@@ -1635,23 +1630,24 @@ export default function ChatLayout() {
 
         // 3) 스크롤 위치 복원: 추가된 높이만큼 scrollTop을 더해줌
         //    → 사용자가 보고 있던 지점 그대로 유지
-        setTimeout(() => {
+        requestAnimationFrame(() => {
           const afterHeight = el?.scrollHeight ?? 0;
           const heightDiff = afterHeight - before.scrollHeight;
           if (el) {
-            el.scrollTop = before.scrollTop + heightDiff;
+            const restored = before.scrollTop + heightDiff;
+            el.scrollTop = restored;
             console.log("✅ [ChatLayout] 스크롤 위치 복원:", {
               before: before.scrollTop,
               heightDiff,
-              after: el.scrollTop
+              restored,
+              actual: el.scrollTop
             });
           }
-        }, 0);
+        });
       }
     } catch (error) {
       console.error("❌ [ChatLayout] 이전 메시지 로딩 실패:", error);
     } finally {
-      console.log("🏁 [ChatLayout] 로딩 상태 false로 변경");
       setIsLoadingMore(false);
     }
   };


### PR DESCRIPTION
## Summary
- 이전 메시지(20개) 로드 시 scrollHeight/scrollTop을 저장하고 heightDiff로 보정해 위치 유지
- 자동 스크롤 간섭(useEffect 등) 제거하여 무한 스크롤 시 위치 튐 현상 해소
- 초기 진입 시 최신/안읽은 위치로 스크롤하는 흐름은 유지

## Testing
- [ ] 채팅방 진입 시 최신/안읽은 위치로 스크롤 확인
- [ ] 스크롤을 최상단까지 올려 “불러오는 중...” 노출 후 위치 유지 확인
- [ ] 연속으로 여러 페이지 prepend 시에도 위치 유지 확인
- [ ] 새로운 메시지 수신 시 스크롤 이동 조건(초기 접속 제외) 정상 동작 확인