### PR TITLE
fix: keep scroll position when loading older chat messages

### DIFF
--- a/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/JMeterResultAnalyzer.java
@@ -388,3 +388,4 @@ public class JMeterResultAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/MetricsAnalyzer.java
@@ -396,3 +396,4 @@ public class MetricsAnalyzer {
 
 
 
+

--- a/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
+++ b/backend/src/test/java/com/goodee/coreconnect/performance/PerformanceMetricsTest.java
@@ -160,3 +160,4 @@ class PerformanceMetricsTest {
 
 
 
+

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -37,6 +37,7 @@ function ChatMessageList({
         height: "55vh",
         maxHeight: 600,
         overflowY: "auto",
+        overflowAnchor: "none",
         background: "#fafbff",
         px: 3,
         pt: 2,

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -15,6 +15,7 @@ function ChatMessageList({
 }) {
   const { userProfile } = useContext(UserProfileContext) || {};
   const scrollRef = useRef();
+  const restoreRef = useRef({ scrollHeight: 0, scrollTop: 0, pending: false });
 
   const handleScroll = () => {
     const el = scrollRef.current;
@@ -23,10 +24,41 @@ function ChatMessageList({
     // 스크롤이 상단 150px 이내면 onLoadMore 호출
     const isNearTop = el.scrollTop <= 150;
     if (onLoadMore && hasMoreAbove && !loadingAbove && isNearTop) {
-      console.log("🔄 [ChatMessageList] onLoadMore 호출 - 위치:", el.scrollTop);
+      // 로딩 전 위치/높이 저장
+      restoreRef.current = {
+        scrollHeight: el.scrollHeight,
+        scrollTop: el.scrollTop,
+        pending: true,
+      };
+      console.log("🔄 [ChatMessageList] onLoadMore 호출 - 위치 저장:", restoreRef.current);
       onLoadMore(); // 위치 저장/복원은 ChatLayout에서 처리
     }
   };
+
+  // 메시지 길이 변화 또는 로딩 종료 후 스크롤 복원
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const { pending, scrollHeight: prevH, scrollTop: prevT } = restoreRef.current;
+    if (!pending || loadingAbove) return;
+
+    const newH = el.scrollHeight;
+    const diff = newH - prevH;
+    const restored = prevT + diff;
+    el.scrollTop = restored;
+
+    console.log("✅ [ChatMessageList] 스크롤 위치 복원:", {
+      prevH,
+      newH,
+      diff,
+      prevT,
+      restored,
+      actual: el.scrollTop,
+    });
+
+    // 완료 후 초기화
+    restoreRef.current = { scrollHeight: 0, scrollTop: 0, pending: false };
+  }, [messages.length, loadingAbove]);
 
   return (
     <Box

--- a/frontend/src/features/chat/components/ChatMessageList.jsx
+++ b/frontend/src/features/chat/components/ChatMessageList.jsx
@@ -16,6 +16,7 @@ function ChatMessageList({
   const { userProfile } = useContext(UserProfileContext) || {};
   const scrollRef = useRef();
   const restoreRef = useRef({ scrollHeight: 0, scrollTop: 0, pending: false });
+  const prevLoadingAboveRef = useRef(loadingAbove);
 
   const handleScroll = () => {
     const el = scrollRef.current;
@@ -35,12 +36,21 @@ function ChatMessageList({
     }
   };
 
-  // 메시지 길이 변화 또는 로딩 종료 후 스크롤 복원
+  // loadingAbove가 true -> false로 변경될 때만 스크롤 복원 (실시간 메시지 도착 시 스크롤 점프 방지)
   React.useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
+
+    // loadingAbove가 true에서 false로 변경되었는지 확인
+    const wasLoading = prevLoadingAboveRef.current;
+    const isNowNotLoading = !loadingAbove;
+    prevLoadingAboveRef.current = loadingAbove;
+
+    // loadingAbove가 true -> false로 변경되고, pending이 true일 때만 복원
+    if (!wasLoading || !isNowNotLoading) return;
+
     const { pending, scrollHeight: prevH, scrollTop: prevT } = restoreRef.current;
-    if (!pending || loadingAbove) return;
+    if (!pending) return;
 
     const newH = el.scrollHeight;
     const diff = newH - prevH;
@@ -58,7 +68,7 @@ function ChatMessageList({
 
     // 완료 후 초기화
     restoreRef.current = { scrollHeight: 0, scrollTop: 0, pending: false };
-  }, [messages.length, loadingAbove]);
+  }, [loadingAbove]);
 
   return (
     <Box
@@ -271,3 +281,5 @@ function ChatMessageList({
 }
 
 export default ChatMessageList;
+
+

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1631,18 +1631,33 @@ export default function ChatLayout() {
         // 3) 스크롤 위치 복원: 추가된 높이만큼 scrollTop을 더해줌
         //    → 사용자가 보고 있던 지점 그대로 유지
         requestAnimationFrame(() => {
-          const afterHeight = el?.scrollHeight ?? 0;
-          const heightDiff = afterHeight - before.scrollHeight;
-          if (el) {
-            const restored = before.scrollTop + heightDiff;
-            el.scrollTop = restored;
-            console.log("✅ [ChatLayout] 스크롤 위치 복원:", {
-              before: before.scrollTop,
-              heightDiff,
-              restored,
-              actual: el.scrollTop
-            });
-          }
+          requestAnimationFrame(() => {
+            const afterHeight = el?.scrollHeight ?? 0;
+            const heightDiff = afterHeight - before.scrollHeight;
+            if (el) {
+              const restored = before.scrollTop + heightDiff;
+              el.scrollTop = restored;
+              // 재확인 후 필요시 한 번 더 보정
+              if (Math.abs(el.scrollTop - restored) > 2) {
+                setTimeout(() => {
+                  el.scrollTop = restored;
+                  console.log("🔁 [ChatLayout] 스크롤 위치 재보정:", {
+                    before: before.scrollTop,
+                    heightDiff,
+                    restored,
+                    actual: el.scrollTop
+                  });
+                }, 30);
+              } else {
+                console.log("✅ [ChatLayout] 스크롤 위치 복원:", {
+                  before: before.scrollTop,
+                  heightDiff,
+                  restored,
+                  actual: el.scrollTop
+                });
+              }
+            }
+          });
         });
       }
     } catch (error) {

--- a/frontend/src/features/chat/pages/ChatLayout.jsx
+++ b/frontend/src/features/chat/pages/ChatLayout.jsx
@@ -1603,15 +1603,6 @@ export default function ChatLayout() {
 
     setIsLoadingMore(true);
 
-    // 1) 현재 스크롤 높이/위치 저장
-    const el = document.querySelector('.chat-message-list-container');
-    const before = {
-      scrollHeight: el?.scrollHeight ?? 0,
-      scrollTop: el?.scrollTop ?? 0
-    };
-    
-    console.log("💾 [ChatLayout] 스크롤 위치 저장:", before);
-
     try {
       const nextPage = currentPage + 1;
       const res = await fetchChatRoomMessages(selectedRoomId, nextPage, 20);
@@ -1627,40 +1618,6 @@ export default function ChatLayout() {
         // 페이징 상태 업데이트
         setHasMore(!pageData.last);
         setCurrentPage(nextPage);
-
-        // 3) 스크롤 위치 복원: 추가된 높이만큼 scrollTop을 더해줌
-        //    → 사용자가 보고 있던 지점 그대로 유지
-
-        // requestAnimationFrame을 사용하여 DOM 렌더링 완료 후 스크롤 조정
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const afterHeight = el?.scrollHeight ?? 0;
-            const heightDiff = afterHeight - before.scrollHeight;
-            if (el) {
-              const restored = before.scrollTop + heightDiff;
-              el.scrollTop = restored;
-              // 재확인 후 필요시 한 번 더 보정
-              if (Math.abs(el.scrollTop - restored) > 2) {
-                setTimeout(() => {
-                  el.scrollTop = restored;
-                  console.log("🔁 [ChatLayout] 스크롤 위치 재보정:", {
-                    before: before.scrollTop,
-                    heightDiff,
-                    restored,
-                    actual: el.scrollTop
-                  });
-                }, 30);
-              } else {
-                console.log("✅ [ChatLayout] 스크롤 위치 복원:", {
-                  before: before.scrollTop,
-                  heightDiff,
-                  restored,
-                  actual: el.scrollTop
-                });
-              }
-            }
-          });
-        });
       }
     } catch (error) {
       console.error("❌ [ChatLayout] 이전 메시지 로딩 실패:", error);


### PR DESCRIPTION
## Summary
- 이전 메시지 로드 전 스크롤 위치/높이 저장 → prepend 후 heightDiff만큼 보정
- 복원 오차 발생 시 재보정하여 스크롤이 최신 메시지로 밀리는 문제 방지
- ChatMessageList에 overflowAnchor: none 적용으로 브라우저 자동 anchor 무효화
- 자동 스크롤 로직 간섭 없이 무한 스크롤 시 위치 유지

## Testing
- [ ] 채팅방 진입 시 최신/안읽은 위치 스크롤 정상
- [ ] 스크롤 최상단 → “불러오는 중...” → 이전 20개 로드 후 위치 그대로 유지
- [ ] 여러 번 연속 prepend 시에도 위치 튐 없이 유지
- [ ] 새 메시지 수신 시 기존 조건부 스크롤 동작 정상