### PR TITLE
feat: Add nginx load balancer configuration for 100k concurrent users

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,328 @@
+# ================================================================
+# Nginx Load Balancer for 10 Chat Servers
+# 10만명 동시접속 채팅방 - Nginx 로드 밸런서
+# ================================================================
+
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 10000;  # 10,000 동시 연결
+    use epoll;                  # Linux 최적화
+    multi_accept on;            # 여러 연결 동시 수락
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # 로깅 포맷
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    'upstream: $upstream_addr '
+                    'response_time: $upstream_response_time '
+                    'request_time: $request_time';
+
+    log_format json_combined escape=json
+    '{'
+        '"time_local":"$time_local",'
+        '"remote_addr":"$remote_addr",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_response_time":"$upstream_response_time",'
+        '"upstream_addr":"$upstream_addr"'
+    '}';
+
+    access_log /var/log/nginx/access.log main;
+
+    # 성능 최적화
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    keepalive_requests 1000;
+    types_hash_max_size 2048;
+    client_max_body_size 100M;
+    client_body_buffer_size 128k;
+    client_header_buffer_size 16k;
+    large_client_header_buffers 4 32k;
+
+    # Gzip 압축
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript 
+               application/json application/javascript application/xml+rss 
+               application/rss+xml font/truetype font/opentype 
+               application/vnd.ms-fontobject image/svg+xml;
+    gzip_min_length 1000;
+
+    # 버퍼 설정
+    proxy_buffering on;
+    proxy_buffer_size 8k;
+    proxy_buffers 32 8k;
+    proxy_busy_buffers_size 16k;
+
+    # ================================================================
+    # 업스트림 서버 (10대)
+    # ================================================================
+    upstream chat_servers {
+        # Least Connection 알고리즘 (가장 연결 수가 적은 서버로 라우팅)
+        least_conn;
+
+        # 10대 서버
+        server chat-app-1:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-2:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-3:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-4:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-5:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-6:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-7:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-8:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-9:8080 max_fails=3 fail_timeout=30s weight=1;
+        server chat-app-10:8080 max_fails=3 fail_timeout=30s weight=1;
+
+        # Keepalive 연결 유지
+        keepalive 100;
+        keepalive_timeout 60s;
+        keepalive_requests 1000;
+    }
+
+    # ================================================================
+    # HTTP 서버
+    # ================================================================
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name _;
+
+        # 접속 로그 (JSON 형식)
+        access_log /var/log/nginx/chat-access.log json_combined;
+        error_log /var/log/nginx/chat-error.log warn;
+
+        # ----------------------------------------------------------------
+        # Health Check 엔드포인트
+        # ----------------------------------------------------------------
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+            add_header X-Server-Name $hostname;
+        }
+
+        # ----------------------------------------------------------------
+        # Nginx 상태 확인 (모니터링용)
+        # ----------------------------------------------------------------
+        location /nginx_status {
+            stub_status on;
+            access_log off;
+            allow 172.20.0.0/16;  # Docker 네트워크만 허용
+            deny all;
+        }
+
+        # ----------------------------------------------------------------
+        # WebSocket 엔드포인트 (/ws)
+        # ----------------------------------------------------------------
+        location /ws {
+            proxy_pass http://chat_servers;
+            
+            # WebSocket 프록시 설정
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # 기본 헤더
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port $server_port;
+            
+            # 타임아웃 (WebSocket 장시간 연결)
+            proxy_connect_timeout 7d;
+            proxy_send_timeout 7d;
+            proxy_read_timeout 7d;
+            
+            # 버퍼링 비활성화 (실시간 전송)
+            proxy_buffering off;
+            proxy_cache off;
+            
+            # WebSocket 연결 유지
+            proxy_http_version 1.1;
+            proxy_redirect off;
+        }
+
+        # ----------------------------------------------------------------
+        # STOMP WebSocket 엔드포인트 (/ws/chat)
+        # ----------------------------------------------------------------
+        location /ws/chat {
+            proxy_pass http://chat_servers;
+            
+            # WebSocket 프록시 설정
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            
+            # 기본 헤더
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # 타임아웃
+            proxy_connect_timeout 7d;
+            proxy_send_timeout 7d;
+            proxy_read_timeout 7d;
+            
+            # 버퍼링 비활성화
+            proxy_buffering off;
+            proxy_cache off;
+        }
+
+        # ----------------------------------------------------------------
+        # API 엔드포인트 (/api)
+        # ----------------------------------------------------------------
+        location /api {
+            proxy_pass http://chat_servers;
+            
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header Connection "";
+            
+            # 타임아웃
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+            
+            # 에러 처리
+            proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+            proxy_next_upstream_tries 3;
+            proxy_next_upstream_timeout 30s;
+        }
+
+        # ----------------------------------------------------------------
+        # Actuator 엔드포인트 (/actuator) - 모니터링
+        # ----------------------------------------------------------------
+        location /actuator {
+            proxy_pass http://chat_servers;
+            
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+            
+            # 타임아웃
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+            
+            # 인증 필요 (Production에서는 Basic Auth 추가)
+            # auth_basic "Monitoring";
+            # auth_basic_user_file /etc/nginx/.htpasswd;
+            
+            # 내부 네트워크만 허용
+            allow 172.20.0.0/16;  # Docker 네트워크
+            allow 127.0.0.1;       # Localhost
+            deny all;
+        }
+
+        # ----------------------------------------------------------------
+        # 정적 파일 및 기타 요청
+        # ----------------------------------------------------------------
+        location / {
+            proxy_pass http://chat_servers;
+            
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection "";
+            
+            # 타임아웃
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+            
+            # 캐싱 (정적 파일)
+            proxy_cache_valid 200 302 10m;
+            proxy_cache_valid 404 1m;
+        }
+
+        # ----------------------------------------------------------------
+        # 파일 업로드 엔드포인트
+        # ----------------------------------------------------------------
+        location /upload {
+            proxy_pass http://chat_servers;
+            
+            client_max_body_size 100M;
+            client_body_buffer_size 128k;
+            
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Connection "";
+            
+            # 타임아웃 증가 (파일 업로드)
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+        }
+
+        # ----------------------------------------------------------------
+        # 에러 페이지
+        # ----------------------------------------------------------------
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            internal;
+            return 503 '{"error": "Service temporarily unavailable"}';
+            add_header Content-Type application/json;
+        }
+
+        error_page 404 /404.html;
+        location = /404.html {
+            internal;
+            return 404 '{"error": "Not found"}';
+            add_header Content-Type application/json;
+        }
+    }
+
+    # ================================================================
+    # HTTPS 서버 (SSL 설정 - 프로덕션용)
+    # ================================================================
+    # server {
+    #     listen 443 ssl http2;
+    #     listen [::]:443 ssl http2;
+    #     server_name your-domain.com;
+    #
+    #     # SSL 인증서
+    #     ssl_certificate /etc/nginx/ssl/fullchain.pem;
+    #     ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+    #
+    #     # SSL 설정
+    #     ssl_protocols TLSv1.2 TLSv1.3;
+    #     ssl_ciphers HIGH:!aNULL:!MD5;
+    #     ssl_prefer_server_ciphers on;
+    #     ssl_session_cache shared:SSL:10m;
+    #     ssl_session_timeout 10m;
+    #
+    #     # 나머지 설정은 HTTP 서버와 동일
+    #     # ...
+    # }
+}
+
+
+


### PR DESCRIPTION
# feat: Add Nginx Load Balancer for 100K Concurrent Users

## 📋 변경사항

### 추가된 파일
- `nginx/nginx.conf`: 10만명 동시접속을 위한 Nginx 로드 밸런서 설정

## 🎯 주요 기능

### 1️⃣ 10대 서버 로드 밸런싱
- **Upstream 설정**: chat-app-1 ~ chat-app-10 (10대 서버)
- **알고리즘**: `least_conn` (연결 수 기반 분산)
- **장애 복구**: `max_fails=3`, `fail_timeout=30s`
- **가중치**: 모든 서버 동일 (weight=1)

### 2️⃣ 대용량 동시 연결 처리
- **Worker Connections**: 10,000개
- **최적화**: epoll (Linux), multi_accept
- **목표**: 10만명 동시접속 지원 (서버당 1만명)

### 3️⃣ WebSocket 장시간 연결 지원
- **타임아웃**: 7일 (proxy_read_timeout, proxy_send_timeout)
- **버퍼링 비활성화**: 실시간 메시지 전송
- **Keepalive**: 연결 재사용으로 성능 향상

### 4️⃣ 성능 최적화
- ✅ Gzip 압축 (텍스트 기반 콘텐츠)
- ✅ Keepalive 연결 유지
- ✅ 프록시 버퍼 최적화
- ✅ 에러 자동 복구 (proxy_next_upstream)

### 5️⃣ 모니터링 & 헬스체크
- `/health`: 서비스 상태 확인
- `/nginx_status`: Nginx 통계 (stub_status)
- `/actuator`: Spring Boot Actuator 프록시

## 📊 성능 목표

| 항목 | AS-IS | TO-BE |
|------|-------|-------|
| **최대 동시 접속** | 10,000명 ❌ | 100,000명 ✅ |
| **메시지 전송 시간** | 1,000초 | 100초 (10배 개선) |
| **장애 대응** | 서비스 중단 | 자동 failover |

## 🔗 관련 문서
- 10만명_동시접속_채팅방_아키텍처.md
- 서버_스케일_아웃_10대_구축_가이드.md

## ✅ 체크리스트
- [x] 10대 서버 upstream 설정 완료
- [x] Least connection 알고리즘 적용
- [x] WebSocket 프록시 설정 완료
- [x] 타임아웃 설정 (7일)
- [x] Gzip 압축 활성화
- [x] 헬스체크 엔드포인트 추가
- [x] 모니터링 엔드포인트 추가
- [x] 에러 처리 및 자동 복구 설정

## 🚀 배포 방법
```bash
# Docker Compose로 실행
docker-compose up -d nginx

# 설정 테스트
docker exec nginx nginx -t

# 설정 리로드
docker exec nginx nginx -s reload
```

## 📝 커밋 정보
- **브랜치**: `feature_scale-out-10-servers`
- **커밋 해시**: `7ac9015`
- **타겟 브랜치**: `main`

