### PR TITLE
feat: Add SECURITY_MODE=open for load testing

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -21,4 +21,7 @@ data:
   
   # JWT
   JWT_EXPIRATION: "86400000"
+  
+  # Security Mode (open: 모든 요청 허용, secure: 인증 필요)
+  SECURITY_MODE: "open"
 


### PR DESCRIPTION
PR Description
📌 변경 이유 (Why)
Kubernetes 환경에서 부하 테스트를 진행하기 위해 Spring Security 설정을 조정해야 했습니다.
현재 애플리케이션은 JWT 인증 기반으로 동작하며, 기본 secure 모드에서는 다음과 같은 문제가 발생했습니다:
/login 페이지 접근 시 401 Unauthorized 에러
채팅 기능 테스트를 위한 사용자 인증 불가
K6 부하 테스트 시나리오 실행 불가 (실제 사용자 시나리오 테스트 필요)
🔧 변경 내용 (What)
ConfigMap에 SECURITY_MODE 환경 변수 추가:
SECURITY_MODE: "open" 설정 추가
이 설정을 통해 SecurityConfig의 모든 요청을 permitAll()로 처리
개발/테스트 환경에서 인증 없이 애플리케이션 접근 가능
변경 파일:
k8s/configmap.yaml
기존 SecurityConfig 동작:
@Value("${security.mode:secure}")private String securityMode;private void configureAuthorization(HttpSecurity http) throws Exception {    if("open".equalsIgnoreCase(securityMode)) {        // 모든 요청 허용        http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());    } else {        // JWT 인증 필요        http.authorizeHttpRequests(auth -> auth            .requestMatchers("/actuator/**", "/login", ...).permitAll()            .anyRequest().authenticated()        );    }}
🎯 기대 효과
부하 테스트 가능 시나리오
✅ 로그인 페이지 접근 (기존: 401 → 변경 후: 200)
✅ 채팅방 입장 및 메시지 전송
✅ WebSocket 연결 및 실시간 통신
✅ K6를 이용한 실제 사용자 시나리오 테스트
K6 부하 테스트 예시
// 이제 가능한 테스트 시나리오export default function() {  // 1. 로그인  let loginRes = http.post(`${BASE_URL}/api/v1/auth/login`, {    email: 'test@test.com',    password: 'password'  });    // 2. 채팅방 입장  let roomRes = http.get(`${BASE_URL}/api/v1/chat/rooms/1`);    // 3. WebSocket 연결  ws.connect(`${WS_URL}/ws/chat`, function(socket) {    socket.send(JSON.stringify({ type: 'CHAT', message: 'Hello!' }));  });}
⚠️ 주의사항
이 설정은 개발/테스트 환경 전용입니다!
🔴 프로덕션 환경에서는 절대 사용 금지
🔴 보안이 완전히 해제되어 모든 API 엔드포인트가 공개됨
부하 테스트 완료 후 SECURITY_MODE: "secure"로 다시 변경 필요
✅ 테스트 방법
1. ConfigMap 적용
kubectl apply -f k8s/configmap.yamlkubectl rollout restart deployment/chat-app -n chat-system
2. Pod 로그 확인
kubectl logs -n chat-system deployment/chat-app --tail=50 | grep "프로필"
예상 출력:
프로필: 개발용
3. 엔드포인트 테스트
# 로그인 페이지 (200 OK 예상)curl -I http://localhost:8080/login# API 테스트 (200 OK 예상)curl http://localhost:8080/api/v1/auth/login
4. K6 부하 테스트 실행
k6 run --vus 10 --duration 30s k6-http-test.js
📋 체크리스트
[x] ConfigMap에 SECURITY_MODE 추가
[x] Git commit & push 완료
[ ] Kubernetes에 ConfigMap 적용
[ ] Deployment 재시작
[ ] 로그인 페이지 접근 확인 (200 OK)
[ ] K6 부하 테스트 실행
[ ] 테스트 완료 후 secure 모드로 복원 계획 수립
🔗 관련 이슈
부하 테스트를 위한 인증 우회 필요
Kubernetes 환경에서 실제 사용자 시나리오 테스트 요구사항
📊 성능 테스트 목표
이 변경으로 다음 성능 테스트를 진행할 예정:
동시 사용자 1,000명 처리 능력
평균 응답 시간 < 1초
95 percentile < 2초
에러율 < 1%
부하 테스트 완료 후 별도 PR로 SECURITY_MODE 제거 예정
